### PR TITLE
Adding command-line args to results object simplified and more consistent 

### DIFF
--- a/account_management/account_management.py
+++ b/account_management/account_management.py
@@ -166,7 +166,8 @@ def main(argv):
     results = Results("Account Management Checker", service_root)
     if output_dir is not None:
         results.set_output_dir(output_dir)
-    results.add_cmd_line_args(opts, args)
+    args_list = [v for opt in opts for v in opt] + args
+    results.add_cmd_line_args(args_list)
     validator = SchemaValidation(rft, service_root, raw_main, results)
     for scenario in scenario_list:
         rc, msg = validate_account_command(rft, account, validator, scenario)

--- a/account_management/account_management.py
+++ b/account_management/account_management.py
@@ -166,7 +166,7 @@ def main(argv):
     results = Results("Account Management Checker", service_root)
     if output_dir is not None:
         results.set_output_dir(output_dir)
-    args_list = [v for opt in opts for v in opt] + args
+    args_list = [argv[0]] + [v for opt in opts for v in opt] + args
     results.add_cmd_line_args(args_list)
     validator = SchemaValidation(rft, service_root, raw_main, results)
     for scenario in scenario_list:

--- a/one_time_boot/one_time_boot.py
+++ b/one_time_boot/one_time_boot.py
@@ -229,21 +229,18 @@ def main(argv):
     output_dir = args.output
     
     print(ip, override, typeBoot, nochkcert, nossl)
-    opts = []
     argsList = []
-    for each in str(args).replace('Namespace(','')[:-1].split(', '):
-        argsplit = each.split('=',1)
-        opts.append(argsplit[0])
-        if argsplit[0] == 'passwd':
-            argsList.append('**********')
+    for name, value in vars(args).items():
+        if name == "passwd":
+            argsList.append(name + "=" + "********")
         else:
-            argsList.append(argsplit[1])
+            argsList.append(name + "=" + str(value))
    
     # create results object
     # how do I report multiple tested systems??
     success, service_root = getServiceRoot(ip, auth=auth, chkCert=(not nochkcert), nossl=nossl)
     results = Results("One Time Boot", service_root if success else dict())
-    results.add_cmd_line_args(opts, argsList)
+    results.add_cmd_line_args(argsList)
     if output_dir is not None:
         results.set_output_dir(output_dir)
 
@@ -266,7 +263,7 @@ def main(argv):
         for sut in sutList:
             rcbool, msg = verifyBoot(sut, override, typeBoot, auth=auth, delay=args.delay, chkCert=(not nochkcert), nossl=nossl)
             rc = 0 if rcbool else 1
-            cntSuccess += 1 if rc else 0
+            cntSuccess += 1 if rc == 0 else 0
             results.update_test_results(sut[1], rc, msg)
         
         msg = '{} out of {} systems passed'.format(cntSuccess, len(sutList))

--- a/one_time_boot/one_time_boot.py
+++ b/one_time_boot/one_time_boot.py
@@ -229,7 +229,7 @@ def main(argv):
     output_dir = args.output
     
     print(ip, override, typeBoot, nochkcert, nossl)
-    argsList = []
+    argsList = [argv[0]]
     for name, value in vars(args).items():
         if name == "passwd":
             argsList.append(name + "=" + "********")

--- a/power_control/power_control.py
+++ b/power_control/power_control.py
@@ -177,7 +177,8 @@ def main(argv):
     results = Results("Power Control Checker", service_root)
     if output_dir is not None:
         results.set_output_dir(output_dir)
-    results.add_cmd_line_args(opts, args)
+    args_list = [v for opt in opts for v in opt] + args
+    results.add_cmd_line_args(args_list)
     validator = SchemaValidation(rft, service_root, raw_main, results)
     rc, msg = validate_reset_command(rft, systems, validator, reset_type)
     results.update_test_results(reset_type, rc, msg)

--- a/power_control/power_control.py
+++ b/power_control/power_control.py
@@ -177,7 +177,7 @@ def main(argv):
     results = Results("Power Control Checker", service_root)
     if output_dir is not None:
         results.set_output_dir(output_dir)
-    args_list = [v for opt in opts for v in opt] + args
+    args_list = [argv[0]] + [v for opt in opts for v in opt] + args
     results.add_cmd_line_args(args_list)
     validator = SchemaValidation(rft, service_root, raw_main, results)
     rc, msg = validate_reset_command(rft, systems, validator, reset_type)

--- a/usecase/results.py
+++ b/usecase/results.py
@@ -38,8 +38,8 @@ class Results(object):
                 self.results["TestResults"]["ErrorMessages"].append(msg)
             self.return_code = rc
 
-    def add_cmd_line_args(self, opts, args):
-        self.results.update({"CommandLineArgs": {"opts": opts, "args": args}})
+    def add_cmd_line_args(self, args):
+        self.results.update({"CommandLineArgs": args})
 
     def set_output_dir(self, output_dir):
         self.output_dir = os.path.abspath(output_dir)

--- a/usecase/validation.py
+++ b/usecase/validation.py
@@ -99,11 +99,13 @@ class SchemaValidation(object):
         Validate the JSON response against the schema
         """
         if json_data is None:
-            self.rft.printErr(1, "SchemaValidation:validate_json: No JSON payload to validate")
-            return 1, "No JSON payload to validate"
+            # JSON payload not required
+            self.rft.printVerbose(1, "SchemaValidation:validate_json: No JSON payload to validate")
+            return 0, None
         if schema is None:
-            self.rft.printErr("SchemaValidation:validate_json: No JSON schema retrieved for validation")
-            return 2, "No JSON schema retrieved for validation"
+            # Redfish schema not required
+            self.rft.printVerbose(1, "SchemaValidation:validate_json: No JSON schema retrieved for validation")
+            return 0, None
         # validate the json response against the schema
         try:
             self.rft.printVerbose(5, "SchemaValidation:validate_json: JSON to be validated: {}".format(json_data))


### PR DESCRIPTION
- Just pass a single arg list for the command args to the results object
- Added the program name (arvg[0]) to the arg list
- Fixes  #6  where checker tools issue error if JSON schema cannot be retrieved
