### PR TITLE
Add example test_conf.json files to each tool dir

### DIFF
--- a/account_management/test_conf.json
+++ b/account_management/test_conf.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "command": "$interpreter account_management.py -r $target_system -u $username -p $password -S $https -d $output_subdir"
+  }
+}

--- a/one_time_boot/test_conf.json
+++ b/one_time_boot/test_conf.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "command": "$interpreter one_time_boot.py $target_system Once Pxe $nochkcert -u $username -p $password --output $output_subdir"
+  }
+}

--- a/power_control/test_conf.json
+++ b/power_control/test_conf.json
@@ -1,0 +1,6 @@
+{
+  "test": {
+    "command": "$interpreter power_control.py -r $target_system -u $username -p $password -S $https -d $output_subdir -I $system_id GracefulRestart",
+    "wait_seconds_after": 180
+  }
+}


### PR DESCRIPTION
These example test_conf.json files will now be in place when running with the Redfish-Test-Framework.