### PR TITLE
Include verify arg in call to SchemaValidation() constructor

### DIFF
--- a/account_management/account_management.py
+++ b/account_management/account_management.py
@@ -177,7 +177,7 @@ def main(argv):
     results.add_cmd_line_args(args_list)
     auth = (rft.user, rft.password)
     nossl = True if rft.secure == "Never" else False
-    validator = SchemaValidation(rft.rhost, service_root, results, auth=auth, nossl=nossl)
+    validator = SchemaValidation(rft.rhost, service_root, results, auth=auth, verify=False, nossl=nossl)
     for scenario in scenario_list:
         rc, msg = validate_account_command(rft, account, validator, scenario)
         results.update_test_results(scenario[1], rc, msg)

--- a/power_control/power_control.py
+++ b/power_control/power_control.py
@@ -188,12 +188,13 @@ def main(argv):
     results.add_cmd_line_args(args_list)
     auth = (rft.user, rft.password)
     nossl = True if rft.secure == "Never" else False
-    validator = SchemaValidation(rft.rhost, service_root, results, auth=auth, nossl=nossl)
+    validator = SchemaValidation(rft.rhost, service_root, results, auth=auth, verify=False, nossl=nossl)
     rc, msg = validate_reset_command(rft, systems, validator, reset_type)
     results.update_test_results(reset_type, rc, msg)
 
     log_results(results)
     exit(results.get_return_code())
+
 
 if __name__ == "__main__":
     main(sys.argv)


### PR DESCRIPTION
When I refactored the SchemaValidation class to not prereq redfishtool, I left off the `verify` param in the call to the constructor. This caused the fetch of the JSON schema to fail on systems using a self-signed cert. Added the param to fix.