### PR TITLE
Various one-time boot test enhancements

### DIFF
--- a/one_time_boot/one_time_boot_check.py
+++ b/one_time_boot/one_time_boot_check.py
@@ -74,9 +74,9 @@ if __name__ == '__main__':
             if test_path is None:
                 print( "{} does not support PXE or USB boot override".format( system ) )
                 results.update_test_results( "Boot Check", 0, "{} does not allow for PXE or USB boot override".format( system ), skipped = True )
-                results.update_test_results( "Continuous Boot Set", 0, "{} does not allow for PXE or USB boot override", skipped = True )
-                results.update_test_results( "Boot Set", 0, "{} does not allow for PXE or USB boot override", skipped = True )
-                results.update_test_results( "Boot Verify", 0, "{} does not allow for PXE or USB boot override", skipped = True )
+                results.update_test_results( "Continuous Boot Set", 0, "{} does not allow for PXE or USB boot override".format( system ), skipped = True )
+                results.update_test_results( "Boot Set", 0, "{} does not allow for PXE or USB boot override".format( system ), skipped = True )
+                results.update_test_results( "Boot Verify", 0, "{} does not allow for PXE or USB boot override".format( system ), skipped = True )
                 continue
             results.update_test_results( "Boot Check", 0, None )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 jsonschema
 redfish>=2.1.0
-redfish_utilities>=1.0.6
+redfish_utilities>=1.0.7


### PR DESCRIPTION
Added check for support of "Continuous".
Refactored error handling to make use of exceptions for easier decision points for logging test results.
Bumped version of redfish_utilities (to pick up https://github.com/DMTF/Redfish-Tacklebox/pull/39).
Added cleanup of the boot object when the test completes.