### PR TITLE
Added missing check for null array members prior to performing property inspection

### DIFF
--- a/manager_ethernet_interface/manager_ethernet_interface_check.py
+++ b/manager_ethernet_interface/manager_ethernet_interface_check.py
@@ -139,6 +139,10 @@ if __name__ == '__main__':
                         # Check for expected IPv4 properties
                         if property in property_ip_list:
                             for i, address in enumerate( interface_resp.dict[property] ):
+                                # Skip null entries
+                                if address is None:
+                                    continue
+
                                 # Check that there is only a Gateway for index 0
                                 if "IPv4" in property:
                                     if "Gateway" in address and i != 0:


### PR DESCRIPTION
Uncovered a corner case while testing on some systems. Null can be found in static address arrays for slots not configured, so property inspection is not needed on those entries.