### PR TITLE
Enhanced Reports

### DIFF
--- a/redfish_use_case_checkers/console_scripts.py
+++ b/redfish_use_case_checkers/console_scripts.py
@@ -14,8 +14,8 @@ Brief : This file contains the definitions and functionalities for invoking
 import argparse
 import colorama
 import logging
-import warnings
-warnings.filterwarnings("ignore", category=Warning, module="requests")
+# import warnings
+# warnings.filterwarnings("ignore", category=Warning, module="requests")
 import redfish
 import sys
 from datetime import datetime

--- a/redfish_use_case_checkers/console_scripts.py
+++ b/redfish_use_case_checkers/console_scripts.py
@@ -14,6 +14,8 @@ Brief : This file contains the definitions and functionalities for invoking
 import argparse
 import colorama
 import logging
+import warnings
+warnings.filterwarnings("ignore", category=Warning, module="requests")
 import redfish
 import sys
 from datetime import datetime
@@ -67,13 +69,13 @@ def main():
     )
     args = argget.parse_args()
 
-    # Create report directory if needed
-    report_dir = Path(args.report_dir)
-    if not report_dir.is_dir():
-        report_dir.mkdir(parents=True)
-
     # Get the current time for report files
     test_time = datetime.now()
+
+    # Create report directory with timestamped subfolder (YYYY-MM-DD-HH-SS)
+    report_dir = Path(args.report_dir) / test_time.strftime("%Y-%m-%d-%H-%S")
+    if not report_dir.is_dir():
+        report_dir.mkdir(parents=True)
 
     # Set the logging level
     log_level = logging.INFO

--- a/redfish_use_case_checkers/console_scripts.py
+++ b/redfish_use_case_checkers/console_scripts.py
@@ -110,9 +110,15 @@ def main():
     sut.logout()
 
     print_summary(sut)
+    print()
     results_file = report.html_report(sut, report_dir, test_time, tool_version)
-    print("HTML Report: {}".format(results_file))
-    print("Debug Log: {}".format(log_file))
+    xlsx_file = report.xlsx_report(sut, report_dir, test_time, tool_version)
+    print("HTML Report:  {}".format(results_file))
+    print()
+    print("Excel Report: {}".format(xlsx_file))
+    print()
+    print("Debug Log:    {}".format(log_file))
+    print()
 
     # Exit with status 1 if there are any failures; 0 otherwise
     sys.exit(int(sut.fail_count > 0))
@@ -149,21 +155,24 @@ def print_summary(sut):
     warn_start, warned, warn_end = summary_format("WARN", sut.warn_count)
     fail_start, failed, fail_end = summary_format("FAIL", sut.fail_count)
     no_test_start, not_tested, no_test_end = summary_format("SKIP", sut.skip_count)
-    print(
-        "Summary - %sPASS: %s%s, %sWARN: %s%s, %sFAIL: %s%s, %sNOT TESTED: %s%s"
-        % (
-            pass_start,
-            passed,
-            pass_end,
-            warn_start,
-            warned,
-            warn_end,
-            fail_start,
-            failed,
-            fail_end,
-            no_test_start,
-            not_tested,
-            no_test_end,
-        )
+
+    col_w = 14
+    sep = "+" + ("-" * col_w + "+") * 4
+    header = "| {:^{w}} | {:^{w}} | {:^{w}} | {:^{w}} |".format(
+        "PASS", "WARN", "FAIL", "NOT TESTED", w=col_w - 2
     )
+    values = "| {}{:^{w}}{} | {}{:^{w}}{} | {}{:^{w}}{} | {}{:^{w}}{} |".format(
+        pass_start, str(passed), pass_end,
+        warn_start, str(warned), warn_end,
+        fail_start, str(failed), fail_end,
+        no_test_start, str(not_tested), no_test_end,
+        w=col_w - 2,
+    )
+    print()
+    print(sep)
+    print(header)
+    print(sep)
+    print(values)
+    print(sep)
+    print()
     colorama.deinit()

--- a/redfish_use_case_checkers/console_scripts.py
+++ b/redfish_use_case_checkers/console_scripts.py
@@ -14,8 +14,6 @@ Brief : This file contains the definitions and functionalities for invoking
 import argparse
 import colorama
 import logging
-# import warnings
-# warnings.filterwarnings("ignore", category=Warning, module="requests")
 import redfish
 import sys
 from datetime import datetime

--- a/redfish_use_case_checkers/console_scripts.py
+++ b/redfish_use_case_checkers/console_scripts.py
@@ -72,8 +72,8 @@ def main():
     # Get the current time for report files
     test_time = datetime.now()
 
-    # Create report directory with timestamped subfolder (YYYY-MM-DD-HH-SS)
-    report_dir = Path(args.report_dir) / test_time.strftime("%Y-%m-%d-%H-%S")
+    # Create report directory with timestamped subfolder (YYYY-MM-DD-HHMMSS)
+    report_dir = Path(args.report_dir) / test_time.strftime("%Y-%m-%d-%H%M%S")
     if not report_dir.is_dir():
         report_dir.mkdir(parents=True)
 
@@ -111,12 +111,10 @@ def main():
 
     print_summary(sut)
     print()
-    results_file = report.html_report(sut, report_dir, test_time, tool_version)
+    results_file = report.html_report(sut, report_dir, test_time, tool_version, vars(args))
     xlsx_file = report.xlsx_report(sut, report_dir, test_time, tool_version)
     print("HTML Report:  {}".format(results_file))
-    print()
     print("Excel Report: {}".format(xlsx_file))
-    print()
     print("Debug Log:    {}".format(log_file))
     print()
 

--- a/redfish_use_case_checkers/report.py
+++ b/redfish_use_case_checkers/report.py
@@ -25,196 +25,268 @@ html_template = """<!DOCTYPE html>
     *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
     :root {{
       --primary:       #1a3a5c;
-      --primary-light: #2c5282;
-      --accent:        #3182ce;
+      --primary-light: #0d6efd;
+      --accent:        #0d6efd;
+      --header-main-h: 56px;
+      --header-total-h: var(--header-main-h);
       --pass-color:  #276749; --pass-bg:  #c6f6d5; --pass-border:  #38a169;
       --warn-color:  #744210; --warn-bg:  #fefcbf; --warn-border:  #d69e2e;
       --fail-color:  #742a2a; --fail-bg:  #fed7d7; --fail-border:  #e53e3e;
       --skip-color:  #4a5568; --skip-bg:  #e2e8f0; --skip-border:  #a0aec0;
-      --border:   #e2e8f0;
-      --text:     #2d3748;
-      --text-sub: #718096;
-      --bg:       #f7fafc;
+      --border:   #dde3ec;
+      --text:     #1a1a2e;
+      --text-sub: #6c757d;
+      --bg:       #f0f2f5;
       --card-bg:  #ffffff;
     }}
     body {{
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, sans-serif;
+      font-family: "Segoe UI", system-ui, Arial, sans-serif;
+      font-size: 13px;
       background: var(--bg);
       color: var(--text);
       line-height: 1.5;
+      display: flex;
+      flex-direction: column;
     }}
 
     /* ── Header ── */
     .header {{
-      background: var(--primary);
-      color: #fff;
-      padding: 0 2rem;
-      height: 64px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      box-shadow: 0 2px 8px rgba(0,0,0,.3);
       position: sticky;
       top: 0;
       z-index: 100;
+      box-shadow: 0 2px 10px rgba(0,0,0,.35);
+    }}
+    .header-main {{
+      background: linear-gradient(90deg, #0d1b2a 0%, #1a3a5c 60%, #1565c0 100%);
+      color: #fff;
+      padding: 0 16px;
+      height: var(--header-main-h);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      position: relative;
     }}
     .header-brand    {{ display: flex; align-items: center; gap: .9rem; }}
-    .header-logo img {{ height: 40px; }}
-    .header-title    {{ font-size: 1.05rem; font-weight: 600; letter-spacing: .02em; }}
-    .header-subtitle {{ font-size: .73rem; opacity: .75; }}
-    .header-meta     {{ text-align: right; font-size: .78rem; opacity: .85; line-height: 1.7; }}
-    .header-meta a   {{ color: rgba(255,255,255,.7); font-size: .7rem; text-decoration: none; }}
+    .header-logo img {{ height: 34px; border-radius: 4px; }}
+    .header-title    {{ font-size: 15px; font-weight: 700; letter-spacing: .3px; white-space: nowrap; }}
+    .header-subtitle {{ font-size: 11px; color: rgba(255,255,255,.55); white-space: nowrap; }}
+    .header-meta     {{ color: rgba(255,255,255,.7); font-size: 11px; text-align: right; line-height: 1.5; margin-left: auto; flex-shrink: 0; }}
+    .header-meta a   {{ color: #90caf9; text-decoration: none; }}
+    .header-meta a:hover {{ text-decoration: underline; }}
+    .header-filter-wrap {{
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 380px;
+    }}
+    .header-filter-shell {{ position: relative; width: 100%; }}
+    .header-filter-icon {{
+      position: absolute;
+      left: 10px;
+      top: 50%;
+      transform: translateY(-50%);
+      color: rgba(255,255,255,.5);
+      font-size: 14px;
+      pointer-events: none;
+    }}
+    .header-filter {{
+      width: 100%;
+      height: 30px;
+      border-radius: 20px;
+      border: 1px solid rgba(255,255,255,.35);
+      background: rgba(255,255,255,.12);
+      color: #f8fbff;
+      padding: 0 30px;
+      font-size: 12px;
+      font-family: "Cascadia Code", "Consolas", monospace;
+      outline: none;
+      transition: border-color .2s, box-shadow .2s;
+    }}
+    .header-filter::placeholder {{ color: rgba(255,255,255,.45); }}
+    .header-filter:focus {{
+      border-color: #90caf9;
+      box-shadow: 0 0 0 3px rgba(144,202,249,.2);
+      background: rgba(255,255,255,.18);
+    }}
+    .header-filter-clear {{
+      position: absolute;
+      right: 9px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: none;
+      border: none;
+      color: rgba(255,255,255,.5);
+      cursor: pointer;
+      font-size: 13px;
+      line-height: 1;
+      display: none;
+    }}
+    .header-filter-clear:hover {{ color: #ef5350; }}
+    .header-filter-note {{
+      font-size: 10px;
+      color: rgba(255,255,255,.5);
+      margin-top: 2px;
+      text-align: center;
+      white-space: nowrap;
+    }}
+    .header-filter-note b {{ color: #90caf9; }}
 
     /* ── Page layout ── */
-    .page-wrap {{ display: flex; align-items: flex-start; min-height: calc(100vh - 64px); }}
+    .page-wrap {{ display: flex; align-items: flex-start; min-height: calc(100vh - var(--header-total-h)); }}
     .sidebar {{
-      width: 240px;
+      width: 300px;
       flex-shrink: 0;
       background: #ffffff;
       border-right: 1px solid #dde3ec;
-      box-shadow: 2px 0 8px rgba(0,0,0,.05);
-      padding: 1.4rem 1rem 2rem;
+      box-shadow: 2px 0 8px rgba(0,0,0,.04);
+      padding: 16px 18px 10px;
       position: sticky;
-      top: 64px;
-      height: calc(100vh - 64px);
+      top: var(--header-total-h);
+      height: calc(100vh - var(--header-total-h));
       overflow-y: auto;
     }}
-    .main-content {{ flex: 1; padding: 1.5rem; min-width: 0; }}
+    .main-content {{ flex: 1; min-width: 0; padding: 20px 24px 60px; overflow-y: auto; }}
 
     /* ── Sidebar section headings ── */
     .sb-heading {{
-      font-size: .6rem;
+      font-size: 10px;
       font-weight: 800;
       text-transform: uppercase;
-      letter-spacing: .12em;
-      color: var(--primary);
-      padding: .3rem .5rem;
-      background: #eef3fa;
-      border-left: 3px solid var(--accent);
-      border-radius: 0 4px 4px 0;
-      margin-bottom: .65rem;
+      letter-spacing: 1px;
+      color: #8a97aa;
+      margin-bottom: 10px;
+      border: none;
+      background: transparent;
+      padding: 0;
+      border-radius: 0;
     }}
-    .sb-stats + .sb-heading {{ margin-top: 1.4rem; }}
+    .sb-stats + .sb-heading {{ margin-top: 16px; }}
 
     /* ── Sidebar info rows ── */
     .sb-row {{
       display: flex;
       justify-content: space-between;
-      align-items: baseline;
+      align-items: flex-start;
       gap: .5rem;
-      padding: .32rem 0;
-      border-bottom: 1px solid #f0f3f7;
-      font-size: .78rem;
+      padding: 4px 0;
+      border-bottom: none;
+      font-size: 12px;
     }}
     .sb-row:last-of-type {{ border-bottom: none; }}
     .sb-key {{
-      color: #64748b;
-      font-size: .67rem;
+      color: #6c757d;
+      font-size: 12px;
       font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: .05em;
       white-space: nowrap;
       flex-shrink: 0;
+      min-width: 90px;
     }}
     .sb-val {{
       font-weight: 600;
-      color: #1e293b;
+      color: #333;
       word-break: break-all;
       text-align: right;
-      font-size: .78rem;
+      font-size: 12px;
     }}
 
     /* ── Sidebar summary stat blocks — 2×2 grid ── */
     .sb-stats {{
       display: grid;
       grid-template-columns: 1fr 1fr;
-      gap: .5rem;
-      margin-top: .4rem;
+      gap: 8px;
+      margin-top: 0;
     }}
     .sb-stat {{
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      padding: .7rem .4rem .55rem;
+      padding: 10px 12px;
       border-radius: 8px;
       font-weight: 700;
       color: #fff;
       text-align: center;
-      min-height: 66px;
+      min-height: 72px;
     }}
-    .sb-stat-count {{ font-size: 1.7rem; line-height: 1; letter-spacing: -.02em; }}
-    .sb-stat-label {{ font-size: .58rem; text-transform: uppercase; letter-spacing: .08em; margin-top: .25rem; opacity: .92; line-height: 1.2; }}
-    .sb-stat.pass {{ background: #2d9e55; }}
-    .sb-stat.warn {{ background: #c98209; }}
-    .sb-stat.fail {{ background: #c0392b; }}
-    .sb-stat.skip {{ background: #5a6b7d; }}
+    .sb-stat-count {{ font-size: 26px; line-height: 1.1; letter-spacing: -.02em; }}
+    .sb-stat-label {{ font-size: 10px; text-transform: uppercase; letter-spacing: .7px; margin-top: 2px; opacity: .9; line-height: 1.2; }}
+    .sb-stat.pass {{ background: linear-gradient(135deg, #27ae60, #2ecc71); }}
+    .sb-stat.warn {{ background: linear-gradient(135deg, #d68910, #f39c12); }}
+    .sb-stat.fail {{ background: linear-gradient(135deg, #c0392b, #e74c3c); }}
+    .sb-stat.skip {{ background: linear-gradient(135deg, #5d6d7e, #85929e); }}
 
     /* ── Section ── */
     .section {{ margin-bottom: 1.5rem; }}
     .section-header {{
-      background: var(--primary-light);
-      color: #fff;
-      padding: .75rem 1.25rem;
+      background: #f7f9fc;
+      color: #0d1b2a;
+      padding: 10px 16px;
       border-radius: 8px 8px 0 0;
       font-weight: 600;
-      font-size: .88rem;
-      letter-spacing: .03em;
+      font-size: 13px;
+      letter-spacing: .01em;
       display: flex;
       align-items: center;
       gap: .55rem;
       cursor: pointer;
       user-select: none;
+      border-bottom: 1px solid #dde3ec;
     }}
-    .section-arrow {{ font-size: .65rem; transition: transform .2s; }}
+    .section-arrow {{ font-size: .7rem; color: #6c757d; transition: transform .2s; }}
     .section-header.collapsed .section-arrow {{ transform: rotate(-90deg); }}
     .section-body {{
       border: 1px solid var(--border);
       border-top: none;
       border-radius: 0 0 8px 8px;
       overflow: hidden;
+      box-shadow: 0 1px 3px rgba(0,0,0,.05);
+      margin-bottom: 8px;
     }}
 
     /* ── Test block ── */
     .test-block {{ border-bottom: 1px solid var(--border); }}
     .test-block:last-child {{ border-bottom: none; }}
     .test-heading {{
-      background: #f8f9fa;
-      padding: .7rem 1.25rem;
+      background: #fff;
+      padding: 10px 16px;
       cursor: pointer;
       display: flex;
       justify-content: space-between;
       align-items: flex-start;
       gap: 1rem;
     }}
-    .test-heading:hover {{ background: #eef2f7; }}
-    .test-name   {{ font-weight: 600; font-size: .87rem; color: var(--primary); }}
-    .test-desc   {{ font-size: .79rem; color: var(--text-sub); margin-top: .12rem; }}
-    .test-detail {{ font-size: .76rem; color: var(--text-sub); margin-top: .08rem; font-style: italic; }}
+    .test-heading:hover {{ background: #f8fafc; }}
+    .test-name   {{ font-weight: 700; font-size: 13px; color: #0d1b2a; font-family: "Cascadia Code", "Consolas", monospace; }}
+    .test-desc   {{ font-size: 11px; color: #6c757d; margin-top: .12rem; font-style: italic; }}
+    .test-detail {{ font-size: 11px; color: #6c757d; margin-top: .08rem; font-style: italic; }}
     .test-toggle {{ flex-shrink: 0; font-size: .65rem; color: var(--text-sub); margin-top: .3rem; transition: transform .2s; }}
     .test-body         {{ display: block; }}
     .test-body.hidden  {{ display: none; }}
 
     /* ── Results table ── */
-    .test-results-table {{ width: 100%; border-collapse: collapse; font-size: .83rem; }}
-    .test-results-table thead tr {{ background: #edf2f7; }}
+    .test-results-table {{ width: 100%; border-collapse: collapse; font-size: 12px; }}
+    .test-results-table thead tr {{ background: #f0f4f8; }}
     .test-results-table th {{
-      padding: .45rem 1.25rem;
+      padding: 7px 12px;
       text-align: left;
-      font-weight: 600;
-      font-size: .7rem;
-      text-transform: uppercase;
-      letter-spacing: .05em;
-      color: var(--text-sub);
-      border-bottom: 1px solid var(--border);
+      font-weight: 700;
+      font-size: 11px;
+      color: #2c3e50;
+      border-bottom: 2px solid #dde3ec;
     }}
     .test-results-table td {{
-      padding: .5rem 1.25rem;
-      border-bottom: 1px solid #f0f0f0;
+      padding: 5px 12px;
+      border-bottom: 1px solid #f0f2f5;
       vertical-align: top;
+      color: #333;
+      background: #fff;
     }}
     .test-results-table tr:last-child td {{ border-bottom: none; }}
-    .test-results-table tr:hover td {{ background: #f7fafc; }}
+    .test-results-table tr:hover td {{ background: #f8fafc; }}
     .col-op     {{ width: 38%; }}
     .col-result {{ width:  9%; white-space: nowrap; }}
     .col-msg    {{ width: 53%; }}
@@ -229,10 +301,10 @@ html_template = """<!DOCTYPE html>
       letter-spacing: .04em;
       text-transform: uppercase;
     }}
-    .badge-pass {{ background: var(--pass-bg); color: var(--pass-color); }}
-    .badge-warn {{ background: var(--warn-bg); color: var(--warn-color); }}
-    .badge-fail {{ background: var(--fail-bg); color: var(--fail-color); }}
-    .badge-skip {{ background: var(--skip-bg); color: var(--skip-color); }}
+    .badge-pass {{ background: #d4edda; color: #145a32; }}
+    .badge-warn {{ background: #fff3cd; color: #7d6008; }}
+    .badge-fail {{ background: #f8d7da; color: #7b241c; }}
+    .badge-skip {{ background: #f5f7fa; color: #7f8c8d; }}
 
     /* ── Toolbar ── */
     .toolbar {{
@@ -242,18 +314,19 @@ html_template = """<!DOCTYPE html>
       margin-bottom: 1rem;
     }}
     .toolbar-btn {{
-      background: var(--primary-light);
+      background: #0d6efd;
       color: #fff;
       border: none;
-      border-radius: 6px;
-      padding: .4rem .9rem;
-      font-size: .78rem;
+      border-radius: 5px;
+      padding: 5px 13px;
+      font-size: 11px;
       font-weight: 600;
       cursor: pointer;
       letter-spacing: .02em;
       transition: background .15s;
+      box-shadow: 0 2px 5px rgba(13,110,253,.3);
     }}
-    .toolbar-btn:hover {{ background: var(--primary); }}
+    .toolbar-btn:hover {{ background: #0b5ed7; }}
 
     /* ── Scroll-to-top ── */
     #scroll-top {{
@@ -263,19 +336,19 @@ html_template = """<!DOCTYPE html>
       width: 42px;
       height: 42px;
       border-radius: 50%;
-      background: var(--primary-light);
+      background: #0d6efd;
       color: #fff;
       border: none;
       font-size: 1.1rem;
       cursor: pointer;
-      box-shadow: 0 3px 10px rgba(0,0,0,.25);
+      box-shadow: 0 4px 14px rgba(13,110,253,.45);
       display: none;
       align-items: center;
       justify-content: center;
       z-index: 200;
       transition: background .15s, opacity .2s;
     }}
-    #scroll-top:hover {{ background: var(--primary); }}
+    #scroll-top:hover {{ background: #0b5ed7; }}
     #scroll-top.visible {{ display: flex; }}
 
     /* ── Footer ── */
@@ -304,11 +377,11 @@ html_template = """<!DOCTYPE html>
 
     /* ── Section count badges ── */
     .section-counts {{ display: flex; gap: .35rem; margin-left: auto; flex-shrink: 0; align-items: center; }}
-    .scnt {{ padding: .12rem .58rem; border-radius: 9999px; font-size: .7rem; font-weight: 700; letter-spacing: .03em; }}
-    .scnt-pass {{ background: rgba(56,161,105,.35);   color: #c6f6d5; }}
-    .scnt-warn {{ background: rgba(214,158,46,.35);  color: #fefcbf; }}
-    .scnt-fail {{ background: rgba(229,62,62,.35);    color: #fed7d7; }}
-    .scnt-skip {{ background: rgba(160,174,192,.3);  color: #e2e8f0; }}
+    .scnt {{ padding: 2px 8px; border-radius: 20px; font-size: 11px; font-weight: 700; letter-spacing: .01em; }}
+    .scnt-pass {{ background: #d4edda; color: #145a32; }}
+    .scnt-warn {{ background: #fff3cd; color: #7d6008; }}
+    .scnt-fail {{ background: #f8d7da; color: #7b241c; }}
+    .scnt-skip {{ background: #f5f7fa; color: #7f8c8d; }}
 
     /* ── Test block status left border ── */
     .test-block.tb-fail {{ border-left: 4px solid var(--fail-border); }}
@@ -366,23 +439,48 @@ html_template = """<!DOCTYPE html>
     .sb-prog-lbl.warn {{ color: #c98209; }}
     .sb-prog-lbl.fail {{ color: #c0392b; }}
     .sb-prog-lbl.skip {{ color: #94a3b8; }}
+
+    @media (max-width: 860px) {{
+      .header-filter-wrap {{ width: 240px; }}
+      .header-meta {{ display: none; }}
+    }}
+
+    @media (max-width: 540px) {{
+      .header-main {{ padding: 0 10px; }}
+      .header-logo img {{ height: 28px; }}
+      .header-brand > div:last-child {{ display: none; }}
+      .header-filter-wrap {{ width: 180px; }}
+      .sidebar {{ width: 260px; }}
+    }}
   </style>
 </head>
 <body>
 
 <header class="header">
-  <div class="header-brand">
-    <div class="header-logo">
-      <img src="data:image/gif;base64,{}" alt="DMTF Redfish Logo">
+  <div class="header-main">
+    <div class="header-brand">
+      <div class="header-logo">
+        <img src="data:image/gif;base64,{}" alt="DMTF Redfish Logo">
+      </div>
+      <div>
+        <div class="header-title">Redfish Use Case Checkers</div>
+        <div class="header-subtitle">Test Report</div>
+      </div>
     </div>
-    <div>
-      <div class="header-title">Redfish Use Case Checkers</div>
-      <div class="header-subtitle">Automated Compliance Report &mdash; v{}</div>
+
+    <div class="header-filter-wrap">
+      <div class="header-filter-shell">
+        <span class="header-filter-icon">&#8260;</span>
+        <input id="header-uri-filter" class="header-filter" type="text" placeholder="Filter by Use Case..." aria-label="Filter by Use Case" autocomplete="off">
+        <button id="header-filter-clear" class="header-filter-clear" title="Clear">&#10005;</button>
+      </div>
+      <div class="header-filter-note">Showing <b id="header-filter-count">...</b> test blocks</div>
     </div>
-  </div>
-  <div class="header-meta">
-    Generated: {}<br>
-    <a href="https://github.com/DMTF/Redfish-Use-Case-Checkers">github.com/DMTF/Redfish-Use-Case-Checkers</a>
+
+    <div class="header-meta">
+      Version: {} &nbsp;|&nbsp; Generated: {}<br>
+      <a href="https://github.com/DMTF/Redfish-Use-Case-Checkers">github.com/DMTF/Redfish-Use-Case-Checkers</a>
+    </div>
   </div>
 </header>
 
@@ -390,7 +488,7 @@ html_template = """<!DOCTYPE html>
 
   <aside class="sidebar">
     <div class="sb-heading">System Under Test</div>
-    <div class="sb-row"><span class="sb-key">Host</span><span class="sb-val">{}/redfish/v1/</span></div>
+    <div class="sb-row"><span class="sb-key">Host</span><span class="sb-val">{}</span></div>
     <div class="sb-row"><span class="sb-key">User</span><span class="sb-val"><strong>{}</strong></span></div>
     <div class="sb-row"><span class="sb-key">Password</span><span class="sb-val">{}</span></div>
     <div class="sb-row"><span class="sb-key">Product</span><span class="sb-val">{}</span></div>
@@ -550,6 +648,64 @@ html_template = """<!DOCTYPE html>
       }});
     }}, 120);
   }})();
+
+  /* Header URI filter (section and test title text match) */
+  (function() {{
+    var filter = document.getElementById('header-uri-filter');
+    var clearBtn = document.getElementById('header-filter-clear');
+    var countEl = document.getElementById('header-filter-count');
+    if (!filter) return;
+
+    function updateCount() {{
+      var allTests = document.querySelectorAll('.test-block').length;
+      var visibleTests = 0;
+      document.querySelectorAll('.test-block').forEach(function(tb) {{
+        if (tb.style.display !== 'none') visibleTests += 1;
+      }});
+      if (countEl) countEl.textContent = visibleTests + ' / ' + allTests;
+      if (clearBtn) clearBtn.style.display = filter.value.trim() ? 'block' : 'none';
+    }}
+
+    if (clearBtn) {{
+      clearBtn.addEventListener('click', function() {{
+        filter.value = '';
+        filter.dispatchEvent(new Event('input'));
+      }});
+    }}
+
+    filter.addEventListener('input', function() {{
+      var q = (this.value || '').toLowerCase().trim();
+      var sections = document.querySelectorAll('.section');
+
+      sections.forEach(function(section) {{
+        var sectionHdr = section.querySelector('.section-header');
+        var testBlocks = section.querySelectorAll('.test-block');
+        var sectionMatches = false;
+
+        testBlocks.forEach(function(tb) {{
+          var heading = tb.querySelector('.test-heading');
+          var txt = heading ? heading.textContent.toLowerCase() : '';
+          var match = !q || txt.indexOf(q) !== -1;
+          tb.style.display = match ? '' : 'none';
+          if (match) sectionMatches = true;
+        }});
+
+        if (sectionHdr && !sectionMatches && q) {{
+          var secTxt = sectionHdr.textContent.toLowerCase();
+          if (secTxt.indexOf(q) !== -1) {{
+            sectionMatches = true;
+            testBlocks.forEach(function(tb) {{ tb.style.display = ''; }});
+          }}
+        }}
+
+        section.style.display = sectionMatches || !q ? '' : 'none';
+      }});
+
+      updateCount();
+    }});
+
+    updateCount();
+  }})();
 </script>
 
 </body>
@@ -692,7 +848,7 @@ def _thin_border():
 def _cell(ws, row, col, value="", bold=False, color=None, fill_hex=None,
           align="left", wrap=False):
     c = ws.cell(row=row, column=col, value=value)
-    c.font = Font(name="Calibri", size=10, bold=bold, color=color or "000000")
+    c.font = Font(name="Segoe UI", size=10, bold=bold, color=color or "1A1A2E")
     c.alignment = Alignment(horizontal=align, vertical="center", wrap_text=wrap)
     c.border = _thin_border()
     if fill_hex:
@@ -722,38 +878,43 @@ def xlsx_report(sut: SystemUnderTest, report_dir, time, tool_version):
     ws_sum = wb.active
     ws_sum.title = "Summary"
 
-    HDR_FILL   = "1A3A5C"
+    HDR_FILL   = "0D1B2A"
     HDR_FONT   = "FFFFFF"
-    SUB_FILL   = "2C5282"
-    META_FILL  = "EDF2F7"
-    PASS_FILL  = "C6F6D5"; PASS_FONT  = "276749"
-    WARN_FILL  = "FEFCBF"; WARN_FONT  = "744210"
-    FAIL_FILL  = "FED7D7"; FAIL_FONT  = "742A2A"
-    SKIP_FILL  = "E2E8F0"; SKIP_FONT  = "4A5568"
-    CAT_FILL   = "2C5282"
-    TEST_FILL  = "EDF2F7"
+    SUB_FILL   = "1A3A5C"
+    ACCENT_FILL= "1565C0"
+    META_FILL  = "F0F2F5"
+    PASS_FILL  = "D4EDDA"; PASS_FONT  = "145A32"
+    WARN_FILL  = "FFF3CD"; WARN_FONT  = "7D6008"
+    FAIL_FILL  = "F8D7DA"; FAIL_FONT  = "7B241C"
+    SKIP_FILL  = "F5F7FA"; SKIP_FONT  = "7F8C8D"
+    CAT_FILL   = "1565C0"
+    TEST_FILL  = "F7F9FC"
+    SCORE_PASS = "27AE60"
+    SCORE_WARN = "D68910"
+    SCORE_FAIL = "C0392B"
+    SCORE_SKIP = "5D6D7E"
 
     # Title row  — spans A:D (4 equal columns)
     ws_sum.merge_cells("A1:D1")
     t = ws_sum["A1"]
     t.value = "Redfish Use Case Checkers — Compliance Report"
-    t.font = Font(name="Calibri", size=14, bold=True, color=HDR_FONT)
+    t.font = Font(name="Segoe UI", size=14, bold=True, color=HDR_FONT)
     t.fill = PatternFill("solid", fgColor=HDR_FILL)
     t.alignment = Alignment(horizontal="center", vertical="center")
-    ws_sum.row_dimensions[1].height = 30
+    ws_sum.row_dimensions[1].height = 32
 
     # Sub-title
     ws_sum.merge_cells("A2:D2")
     s = ws_sum["A2"]
-    s.value = "Tool Version: {}    |    Generated: {}".format(tool_version, time.strftime("%c"))
-    s.font = Font(name="Calibri", size=10, color=HDR_FONT)
+    s.value = "Version: {}    |    Generated: {}".format(tool_version, time.strftime("%c"))
+    s.font = Font(name="Segoe UI", size=10, color=HDR_FONT)
     s.fill = PatternFill("solid", fgColor=SUB_FILL)
     s.alignment = Alignment(horizontal="center", vertical="center")
     ws_sum.row_dimensions[2].height = 18
 
     # Meta info — label in A, value merged B:D
     meta = [
-        ("Target System", "{}/redfish/v1/".format(sut.rhost)),
+        ("Target System", sut.rhost),
         ("User", sut.username),
         ("Product", sut.product),
         ("Manufacturer", sut.manufacturer),
@@ -761,7 +922,7 @@ def xlsx_report(sut: SystemUnderTest, report_dir, time, tool_version):
         ("Firmware", sut.firmware_version),
     ]
     for i, (label, value) in enumerate(meta, start=3):
-        _cell(ws_sum, i, 1, label, bold=True, fill_hex=META_FILL, align="right")
+        _cell(ws_sum, i, 1, label, bold=True, color="6C757D", fill_hex=META_FILL, align="right")
         ws_sum.merge_cells(start_row=i, start_column=2, end_row=i, end_column=4)
         _cell(ws_sum, i, 2, value, fill_hex="FFFFFF")
         # Apply borders to every cell in the merged range so all edges are visible
@@ -770,16 +931,23 @@ def xlsx_report(sut: SystemUnderTest, report_dir, time, tool_version):
 
     # Blank row, then summary counters spanning A:D
     r = 3 + len(meta) + 1
-    for col, label in enumerate(["PASS", "WARN", "FAIL", "NOT TESTED"], start=1):
+    score_labels = [("✓  PASS", SCORE_PASS), ("⚠  WARN", SCORE_WARN),
+                    ("✗  FAIL", SCORE_FAIL), ("–  NOT TESTED", SCORE_SKIP)]
+    for col, (label, fill) in enumerate(score_labels, start=1):
         _cell(ws_sum, r, col, label, bold=True, color=HDR_FONT,
-              fill_hex=HDR_FILL, align="center")
+              fill_hex=fill, align="center")
+        ws_sum.row_dimensions[r].height = 22
     r += 1
-    fills  = [PASS_FILL,  WARN_FILL,  FAIL_FILL,  SKIP_FILL]
-    fonts  = [PASS_FONT,  WARN_FONT,  FAIL_FONT,  SKIP_FONT]
-    counts = [sut.pass_count, sut.warn_count, sut.fail_count, sut.skip_count]
-    for col, (fill, fnt, count) in enumerate(zip(fills, fonts, counts), start=1):
+    score_data = [
+        (sut.pass_count, PASS_FILL, PASS_FONT),
+        (sut.warn_count, WARN_FILL, WARN_FONT),
+        (sut.fail_count, FAIL_FILL, FAIL_FONT),
+        (sut.skip_count, SKIP_FILL, SKIP_FONT),
+    ]
+    for col, (count, fill, fnt) in enumerate(score_data, start=1):
         _cell(ws_sum, r, col, count, bold=True, color=fnt,
               fill_hex=fill, align="center")
+        ws_sum.row_dimensions[r].height = 28
 
     # Column widths — A (label) narrower, B-D equal data columns
     ws_sum.column_dimensions["A"].width = 20
@@ -798,9 +966,9 @@ def xlsx_report(sut: SystemUnderTest, report_dir, time, tool_version):
 
     for col, (hdr, width) in enumerate(zip(col_headers, col_widths), start=1):
         _cell(ws, 1, col, hdr, bold=True, color=HDR_FONT,
-              fill_hex=HDR_FILL, align="center")
+              fill_hex=SUB_FILL, align="center")
         ws.column_dimensions[get_column_letter(col)].width = width
-    ws.row_dimensions[1].height = 20
+    ws.row_dimensions[1].height = 22
     ws.freeze_panes = "A2"
 
     # Hide grid lines on results sheet

--- a/redfish_use_case_checkers/report.py
+++ b/redfish_use_case_checkers/report.py
@@ -6,83 +6,409 @@ import html as html_mod
 import json
 from datetime import datetime
 
+import openpyxl
+from openpyxl.styles import (
+    Alignment, Border, Font, PatternFill, Side
+)
+from openpyxl.utils import get_column_letter
+
 from redfish_use_case_checkers import redfish_logo
 from redfish_use_case_checkers.system_under_test import SystemUnderTest
 
-html_template = """
-<html>
-  <head>
-    <title>Redfish Use Case Checkers Test Summary</title>
-    <style>
-      .pass {{background-color:#99EE99}}
-      .fail {{background-color:#EE9999}}
-      .warn {{background-color:#EEEE99}}
-      .bluebg {{background-color:#BDD6EE}}
-      .button {{padding: 12px; display: inline-block}}
-      .center {{text-align:center;}}
-      .left {{text-align:left;}}
-      .log {{text-align:left; white-space:pre-wrap; word-wrap:break-word;
-             font-size:smaller}}
-      .title {{background-color:#DDDDDD; border: 1pt solid; font-height: 30px;
-               padding: 8px}}
-      .titlesub {{padding: 8px}}
-      .titlerow {{border: 2pt solid}}
-      .headingrow {{border: 2pt solid; text-align:left;
-                    background-color:beige;}}
-      .results {{transition: visibility 0s, opacity 0.5s linear; display: none;
-                 opacity: 0}}
-      .resultsShow {{display: block; opacity: 1}}
-      body {{background-color:lightgrey; border: 1pt solid; text-align:center;
-             margin-left:auto; margin-right:auto}}
-      th {{text-align:center; background-color:beige; border: 1pt solid}}
-      td {{text-align:left; background-color:white; border: 1pt solid;
-           word-wrap:break-word;}}
-      table {{width:90%; margin: 0px auto; table-layout:fixed;}}
-      .titletable {{width:100%}}
-    </style>
-  </head>
-  <table>
-    <tr>
-      <th>
-        <h2>##### Redfish Use Case Checkers Test Report #####</h2>
-        <h4><img align=\"center\" alt=\"DMTF Redfish Logo\" height=\"203\"
-            width=\"288\" src=\"data:image/gif;base64,{}\"></h4>
-        <h4><a href=\"https://github.com/DMTF/Redfish-Use-Case-Checkers\">
-            https://github.com/DMTF/Redfish-Use-Case-Checkers</a></h4>
-        Tool Version: {}<br/>
-        {}<br/><br/>
-        This tool is provided and maintained by the DMTF. For feedback, please
-        open issues<br/> in the tool's Github repository:
-        <a href=\"https://github.com/DMTF/Redfish-Use-Case-Checkers/issues\">
-            https://github.com/DMTF/Redfish-Use-Case-Checkers/issues</a><br/>
-      </th>
-    </tr>
-    <tr>
-      <th>
-        System: {}/redfish/v1/, User: {}, Password: {}<br/>
-        Product: {}<br/>
-        Manufacturer: {}, Model: {}, Firmware version: {}<br/>
-      </th>
-    </tr>
-    <tr>
-      <td>
-        <center><b>Results Summary</b></center>
-        <center>Pass: {}, Warning: {}, Fail: {}, Not tested: {}</center>
-      </td>
-    </tr>
-    {}
-  </table>
-</html>
-"""
+html_template = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Redfish Use Case Checkers Report</title>
+  <style>
+    *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+    :root {{
+      --primary:       #1a3a5c;
+      --primary-light: #2c5282;
+      --accent:        #3182ce;
+      --pass-color:  #276749; --pass-bg:  #c6f6d5; --pass-border:  #38a169;
+      --warn-color:  #744210; --warn-bg:  #fefcbf; --warn-border:  #d69e2e;
+      --fail-color:  #742a2a; --fail-bg:  #fed7d7; --fail-border:  #e53e3e;
+      --skip-color:  #4a5568; --skip-bg:  #e2e8f0; --skip-border:  #a0aec0;
+      --border:   #e2e8f0;
+      --text:     #2d3748;
+      --text-sub: #718096;
+      --bg:       #f7fafc;
+      --card-bg:  #ffffff;
+    }}
+    body {{
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+    }}
 
-section_header_html = """
-  <table>
-    <tr>
-      <th class=\"titlerow bluebg\">
-        <b>{}</b>
-      </th>
-    </tr>
-  </table>
+    /* ── Header ── */
+    .header {{
+      background: var(--primary);
+      color: #fff;
+      padding: 0 2rem;
+      height: 64px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      box-shadow: 0 2px 8px rgba(0,0,0,.3);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }}
+    .header-brand    {{ display: flex; align-items: center; gap: .9rem; }}
+    .header-logo img {{ height: 40px; }}
+    .header-title    {{ font-size: 1.05rem; font-weight: 600; letter-spacing: .02em; }}
+    .header-subtitle {{ font-size: .73rem; opacity: .75; }}
+    .header-meta     {{ text-align: right; font-size: .78rem; opacity: .85; line-height: 1.7; }}
+    .header-meta a   {{ color: rgba(255,255,255,.7); font-size: .7rem; text-decoration: none; }}
+
+    /* ── Layout ── */
+    .container {{ max-width: 1200px; margin: 0 auto; padding: 2rem 1.5rem; }}
+
+    /* ── Info cards ── */
+    .info-grid {{
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }}
+    @media (max-width: 768px) {{ .info-grid {{ grid-template-columns: 1fr; }} }}
+    .card {{
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,.06);
+    }}
+    .card-label {{
+      font-size: .67rem;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--text-sub);
+      font-weight: 600;
+      margin-bottom: .2rem;
+    }}
+    .card-value {{ font-size: .9rem; font-weight: 500; word-break: break-all; }}
+    .hw-table {{ border-collapse: collapse; width: 100%; margin-top: .25rem; font-size: .88rem; }}
+    .hw-table tr {{ border-bottom: 1px solid var(--border); }}
+    .hw-table tr:last-child {{ border-bottom: none; }}
+    .hw-key {{ width: 30%; padding: .3rem .4rem .3rem 0; color: var(--text-sub); font-size: .75rem; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; white-space: nowrap; vertical-align: middle; }}
+    .hw-val {{ padding: .3rem .4rem; font-weight: 500; word-break: break-all; vertical-align: middle; }}
+
+    /* ── Summary counters ── */
+    .summary-grid {{
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }}
+    @media (max-width: 640px) {{ .summary-grid {{ grid-template-columns: repeat(2, 1fr); }} }}
+    .summary-card {{
+      background: var(--card-bg);
+      border-radius: 8px;
+      padding: 1.25rem;
+      text-align: center;
+      border: 1px solid var(--border);
+      box-shadow: 0 1px 3px rgba(0,0,0,.06);
+    }}
+    .summary-card .count {{ font-size: 2.25rem; font-weight: 700; line-height: 1; }}
+    .summary-card .label {{
+      font-size: .68rem;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      font-weight: 600;
+      margin-top: .3rem;
+    }}
+    .summary-card.pass {{ border-top: 4px solid var(--pass-border); }}
+    .summary-card.pass .count {{ color: var(--pass-color); }}
+    .summary-card.pass .label {{ color: var(--pass-border); }}
+    .summary-card.warn {{ border-top: 4px solid var(--warn-border); }}
+    .summary-card.warn .count {{ color: var(--warn-color); }}
+    .summary-card.warn .label {{ color: var(--warn-border); }}
+    .summary-card.fail {{ border-top: 4px solid var(--fail-border); }}
+    .summary-card.fail .count {{ color: var(--fail-color); }}
+    .summary-card.fail .label {{ color: var(--fail-border); }}
+    .summary-card.skip {{ border-top: 4px solid var(--skip-border); }}
+    .summary-card.skip .count {{ color: var(--skip-color); }}
+    .summary-card.skip .label {{ color: var(--skip-border); }}
+
+    /* ── Section ── */
+    .section {{ margin-bottom: 1.5rem; }}
+    .section-header {{
+      background: var(--primary-light);
+      color: #fff;
+      padding: .75rem 1.25rem;
+      border-radius: 8px 8px 0 0;
+      font-weight: 600;
+      font-size: .88rem;
+      letter-spacing: .03em;
+      display: flex;
+      align-items: center;
+      gap: .55rem;
+      cursor: pointer;
+      user-select: none;
+    }}
+    .section-arrow {{ font-size: .65rem; transition: transform .2s; }}
+    .section-header.collapsed .section-arrow {{ transform: rotate(-90deg); }}
+    .section-body {{
+      border: 1px solid var(--border);
+      border-top: none;
+      border-radius: 0 0 8px 8px;
+      overflow: hidden;
+    }}
+
+    /* ── Test block ── */
+    .test-block {{ border-bottom: 1px solid var(--border); }}
+    .test-block:last-child {{ border-bottom: none; }}
+    .test-heading {{
+      background: #f8f9fa;
+      padding: .7rem 1.25rem;
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 1rem;
+    }}
+    .test-heading:hover {{ background: #eef2f7; }}
+    .test-name   {{ font-weight: 600; font-size: .87rem; color: var(--primary); }}
+    .test-desc   {{ font-size: .79rem; color: var(--text-sub); margin-top: .12rem; }}
+    .test-detail {{ font-size: .76rem; color: var(--text-sub); margin-top: .08rem; font-style: italic; }}
+    .test-toggle {{ flex-shrink: 0; font-size: .65rem; color: var(--text-sub); margin-top: .3rem; transition: transform .2s; }}
+    .test-body         {{ display: block; }}
+    .test-body.hidden  {{ display: none; }}
+
+    /* ── Results table ── */
+    .test-results-table {{ width: 100%; border-collapse: collapse; font-size: .83rem; }}
+    .test-results-table thead tr {{ background: #edf2f7; }}
+    .test-results-table th {{
+      padding: .45rem 1.25rem;
+      text-align: left;
+      font-weight: 600;
+      font-size: .7rem;
+      text-transform: uppercase;
+      letter-spacing: .05em;
+      color: var(--text-sub);
+      border-bottom: 1px solid var(--border);
+    }}
+    .test-results-table td {{
+      padding: .5rem 1.25rem;
+      border-bottom: 1px solid #f0f0f0;
+      vertical-align: top;
+    }}
+    .test-results-table tr:last-child td {{ border-bottom: none; }}
+    .test-results-table tr:hover td {{ background: #f7fafc; }}
+    .col-op     {{ width: 38%; }}
+    .col-result {{ width:  9%; white-space: nowrap; }}
+    .col-msg    {{ width: 53%; }}
+
+    /* ── Badges ── */
+    .badge {{
+      display: inline-block;
+      padding: .15rem .55rem;
+      border-radius: 9999px;
+      font-size: .69rem;
+      font-weight: 700;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+    }}
+    .badge-pass {{ background: var(--pass-bg); color: var(--pass-color); }}
+    .badge-warn {{ background: var(--warn-bg); color: var(--warn-color); }}
+    .badge-fail {{ background: var(--fail-bg); color: var(--fail-color); }}
+    .badge-skip {{ background: var(--skip-bg); color: var(--skip-color); }}
+
+    /* ── Toolbar ── */
+    .toolbar {{
+      display: flex;
+      align-items: center;
+      gap: .6rem;
+      margin-bottom: 1rem;
+    }}
+    .toolbar-btn {{
+      background: var(--primary-light);
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      padding: .4rem .9rem;
+      font-size: .78rem;
+      font-weight: 600;
+      cursor: pointer;
+      letter-spacing: .02em;
+      transition: background .15s;
+    }}
+    .toolbar-btn:hover {{ background: var(--primary); }}
+
+    /* ── Scroll-to-top ── */
+    #scroll-top {{
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      width: 42px;
+      height: 42px;
+      border-radius: 50%;
+      background: var(--primary-light);
+      color: #fff;
+      border: none;
+      font-size: 1.1rem;
+      cursor: pointer;
+      box-shadow: 0 3px 10px rgba(0,0,0,.25);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 200;
+      transition: background .15s, opacity .2s;
+    }}
+    #scroll-top:hover {{ background: var(--primary); }}
+    #scroll-top.visible {{ display: flex; }}
+
+    /* ── Footer ── */
+    .footer {{
+      text-align: center;
+      font-size: .77rem;
+      color: var(--text-sub);
+      padding: 2rem 1rem;
+      border-top: 1px solid var(--border);
+      margin-top: 2rem;
+    }}
+    .footer a {{ color: var(--accent); text-decoration: none; }}
+    .footer a:hover {{ text-decoration: underline; }}
+  </style>
+</head>
+<body>
+
+<header class="header">
+  <div class="header-brand">
+    <div class="header-logo">
+      <img src="data:image/gif;base64,{}" alt="DMTF Redfish Logo">
+    </div>
+    <div>
+      <div class="header-title">Redfish Use Case Checkers</div>
+      <div class="header-subtitle">Automated Compliance Report &mdash; v{}</div>
+    </div>
+  </div>
+  <div class="header-meta">
+    Generated: {}<br>
+    <a href="https://github.com/DMTF/Redfish-Use-Case-Checkers">github.com/DMTF/Redfish-Use-Case-Checkers</a>
+  </div>
+</header>
+
+<div class="container">
+
+  <div class="info-grid">
+    <div class="card">
+      <div class="card-label">Target System</div>
+      <div class="card-value">{}/redfish/v1/</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Credentials</div>
+      <div class="card-value">User:&nbsp;<strong>{}</strong>&nbsp;&nbsp;|&nbsp;&nbsp;Password:&nbsp;{}</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Product</div>
+      <div class="card-value">{}</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Hardware</div>
+      <table class="hw-table">
+        <tr><td class="hw-key">Manufacturer</td><td class="hw-val">{}</td></tr>
+        <tr><td class="hw-key">Model</td><td class="hw-val">{}</td></tr>
+        <tr><td class="hw-key">Firmware</td><td class="hw-val">{}</td></tr>
+      </table>
+    </div>
+  </div>
+
+  <div class="summary-grid">
+    <div class="summary-card pass"><div class="count">{}</div><div class="label">Pass</div></div>
+    <div class="summary-card warn"><div class="count">{}</div><div class="label">Warning</div></div>
+    <div class="summary-card fail"><div class="count">{}</div><div class="label">Fail</div></div>
+    <div class="summary-card skip"><div class="count">{}</div><div class="label">Not Tested</div></div>
+  </div>
+
+  <div class="toolbar">
+    <button class="toolbar-btn" onclick="expandAll()">&#9660;&nbsp; Expand All</button>
+    <button class="toolbar-btn" onclick="collapseAll()">&#9654;&nbsp; Collapse All</button>
+  </div>
+
+  {}
+
+</div>
+
+<button id="scroll-top" title="Back to top" onclick="window.scrollTo({{top:0,behavior:'smooth'}})">
+  &#8679;
+</button>
+
+<footer class="footer">
+  This report was generated by the
+  <a href="https://github.com/DMTF/Redfish-Use-Case-Checkers">DMTF Redfish Use Case Checkers</a>.
+  For feedback, please
+  <a href="https://github.com/DMTF/Redfish-Use-Case-Checkers/issues">open an issue</a>.
+</footer>
+
+<script>
+  /* Section collapse/expand */
+  document.querySelectorAll('.section-header').forEach(function(hdr) {{
+    hdr.addEventListener('click', function() {{
+      this.classList.toggle('collapsed');
+      var body = this.nextElementSibling;
+      body.style.display = (body.style.display === 'none') ? '' : 'none';
+    }});
+  }});
+
+  /* Test row collapse/expand */
+  document.querySelectorAll('.test-heading').forEach(function(hdr) {{
+    hdr.addEventListener('click', function() {{
+      var body = this.nextElementSibling;
+      var arrow = this.querySelector('.test-toggle');
+      if (body && body.classList.contains('test-body')) {{
+        var hidden = body.classList.toggle('hidden');
+        if (arrow) arrow.style.transform = hidden ? 'rotate(-90deg)' : '';
+      }}
+    }});
+  }});
+
+  /* Expand all */
+  function expandAll() {{
+    document.querySelectorAll('.section-header').forEach(function(hdr) {{
+      hdr.classList.remove('collapsed');
+      hdr.nextElementSibling.style.display = '';
+    }});
+    document.querySelectorAll('.test-body').forEach(function(b) {{
+      b.classList.remove('hidden');
+    }});
+    document.querySelectorAll('.test-toggle').forEach(function(a) {{
+      a.style.transform = '';
+    }});
+  }}
+
+  /* Collapse all */
+  function collapseAll() {{
+    document.querySelectorAll('.section-header').forEach(function(hdr) {{
+      hdr.classList.add('collapsed');
+      hdr.nextElementSibling.style.display = 'none';
+    }});
+    document.querySelectorAll('.test-body').forEach(function(b) {{
+      b.classList.add('hidden');
+    }});
+    document.querySelectorAll('.test-toggle').forEach(function(a) {{
+      a.style.transform = 'rotate(-90deg)';
+    }});
+  }}
+
+  /* Scroll-to-top button */
+  var scrollBtn = document.getElementById('scroll-top');
+  window.addEventListener('scroll', function() {{
+    if (window.scrollY > 400) {{
+      scrollBtn.classList.add('visible');
+    }} else {{
+      scrollBtn.classList.remove('visible');
+    }}
+  }});
+</script>
+
+</body>
+</html>
 """
 
 
@@ -101,32 +427,59 @@ def html_report(sut: SystemUnderTest, report_dir, time, tool_version):
     """
 
     file = report_dir / datetime.strftime(time, "RedfishUseCaseCheckersReport_%m_%d_%Y_%H%M%S.html")
+
     html = ""
     for test_category in sut._results:
-        html += section_header_html.format(test_category["Category"])
+        html += '<div class="section">'
+        html += '<div class="section-header"><span class="section-arrow">&#9660;</span>{}</div>'.format(
+            html_mod.escape(test_category["Category"])
+        )
+        html += '<div class="section-body">'
+
         for test in test_category["Tests"]:
-            html += "<table>"
-            html += '<th colspan="3" class="headingrow">{}: {}<br/>{}</th>'.format(
-                test["Name"], test["Description"], test["Details"]
-            )
-            html += "<tr><td><b>{}</b></td><td><b>{}</b></td><td><b>{}</b></td></tr>".format(
-                "Operation", "Result", "Message"
+            html += '<div class="test-block">'
+            html += '<div class="test-heading">'
+            html += '<div class="test-heading-info">'
+            html += '<div class="test-name">{}</div>'.format(html_mod.escape(test["Name"]))
+            html += '<div class="test-desc">{}</div>'.format(html_mod.escape(test["Description"]))
+            if test.get("Details"):
+                html += '<div class="test-detail">{}</div>'.format(html_mod.escape(test["Details"]))
+            html += '</div>'  # test-heading-info
+            html += '<span class="test-toggle">&#9660;</span>'
+            html += '</div>'  # test-heading
+
+            html += '<div class="test-body">'
+            html += '<table class="test-results-table">'
+            html += (
+                '<thead><tr>'
+                '<th class="col-op">Operation</th>'
+                '<th class="col-result">Result</th>'
+                '<th class="col-msg">Message</th>'
+                '</tr></thead><tbody>'
             )
             for result in test["Results"]:
-                result_class = ""
                 if result["Result"] == "PASS":
-                    result_class = 'class="pass"'
+                    badge = "badge-pass"
                 elif result["Result"] == "WARN":
-                    result_class = 'class="warn"'
+                    badge = "badge-warn"
                 elif result["Result"] == "FAIL":
-                    result_class = 'class="fail"'
-                operation = result["Operation"]
-                if operation == "":
-                    operation = "No testing performed"
-                html += "<tr><td>{}</td><td {}>{}</td><td>{}</td></tr>".format(
-                    operation, result_class, result["Result"], html_mod.escape(result["Message"])
+                    badge = "badge-fail"
+                else:
+                    badge = "badge-skip"
+                operation = result["Operation"] if result["Operation"] else "No testing performed"
+                html += '<tr><td>{}</td><td><span class="badge {}">{}</span></td><td>{}</td></tr>'.format(
+                    html_mod.escape(operation),
+                    badge,
+                    html_mod.escape(result["Result"]) if result["Result"] else "N/A",
+                    html_mod.escape(result["Message"]),
                 )
-            html += "</table>"
+            html += '</tbody></table>'
+            html += '</div>'  # test-body
+            html += '</div>'  # test-block
+
+        html += '</div>'  # section-body
+        html += '</div>'  # section
+
     with open(str(file), "w", encoding="utf-8") as fd:
         fd.write(
             html_template.format(
@@ -148,3 +501,164 @@ def html_report(sut: SystemUnderTest, report_dir, time, tool_version):
             )
         )
     return file
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _thin_border():
+    side = Side(style="thin", color="BFBFBF")
+    return Border(left=side, right=side, top=side, bottom=side)
+
+
+def _cell(ws, row, col, value="", bold=False, color=None, fill_hex=None,
+          align="left", wrap=False):
+    c = ws.cell(row=row, column=col, value=value)
+    c.font = Font(name="Calibri", size=10, bold=bold, color=color or "000000")
+    c.alignment = Alignment(horizontal=align, vertical="center", wrap_text=wrap)
+    c.border = _thin_border()
+    if fill_hex:
+        c.fill = PatternFill("solid", fgColor=fill_hex)
+    return c
+
+
+def xlsx_report(sut: SystemUnderTest, report_dir, time, tool_version):
+    """
+    Creates the Excel (xlsx) report for the system under test.
+
+    Args:
+        sut: The system under test
+        report_dir: The directory for the report
+        time: The time the tests finished
+        tool_version: The version of the tool
+
+    Returns:
+        The path to the xlsx report
+    """
+
+    file = report_dir / datetime.strftime(time, "RedfishUseCaseCheckersReport_%m_%d_%Y_%H%M%S.xlsx")
+
+    wb = openpyxl.Workbook()
+
+    # ── Summary sheet ────────────────────────────────────────────────────────
+    ws_sum = wb.active
+    ws_sum.title = "Summary"
+
+    HDR_FILL   = "1A3A5C"
+    HDR_FONT   = "FFFFFF"
+    SUB_FILL   = "2C5282"
+    META_FILL  = "EDF2F7"
+    PASS_FILL  = "C6F6D5"; PASS_FONT  = "276749"
+    WARN_FILL  = "FEFCBF"; WARN_FONT  = "744210"
+    FAIL_FILL  = "FED7D7"; FAIL_FONT  = "742A2A"
+    SKIP_FILL  = "E2E8F0"; SKIP_FONT  = "4A5568"
+    CAT_FILL   = "2C5282"
+    TEST_FILL  = "EDF2F7"
+
+    # Title row  — spans A:D (4 equal columns)
+    ws_sum.merge_cells("A1:D1")
+    t = ws_sum["A1"]
+    t.value = "Redfish Use Case Checkers — Compliance Report"
+    t.font = Font(name="Calibri", size=14, bold=True, color=HDR_FONT)
+    t.fill = PatternFill("solid", fgColor=HDR_FILL)
+    t.alignment = Alignment(horizontal="center", vertical="center")
+    ws_sum.row_dimensions[1].height = 30
+
+    # Sub-title
+    ws_sum.merge_cells("A2:D2")
+    s = ws_sum["A2"]
+    s.value = "Tool Version: {}    |    Generated: {}".format(tool_version, time.strftime("%c"))
+    s.font = Font(name="Calibri", size=10, color=HDR_FONT)
+    s.fill = PatternFill("solid", fgColor=SUB_FILL)
+    s.alignment = Alignment(horizontal="center", vertical="center")
+    ws_sum.row_dimensions[2].height = 18
+
+    # Meta info — label in A, value merged B:D
+    meta = [
+        ("Target System", "{}/redfish/v1/".format(sut.rhost)),
+        ("User", sut.username),
+        ("Product", sut.product),
+        ("Manufacturer", sut.manufacturer),
+        ("Model", sut.model),
+        ("Firmware", sut.firmware_version),
+    ]
+    for i, (label, value) in enumerate(meta, start=3):
+        _cell(ws_sum, i, 1, label, bold=True, fill_hex=META_FILL, align="right")
+        ws_sum.merge_cells(start_row=i, start_column=2, end_row=i, end_column=4)
+        _cell(ws_sum, i, 2, value, fill_hex="FFFFFF")
+        # Apply borders to every cell in the merged range so all edges are visible
+        for col in range(2, 5):
+            ws_sum.cell(row=i, column=col).border = _thin_border()
+
+    # Blank row, then summary counters spanning A:D
+    r = 3 + len(meta) + 1
+    for col, label in enumerate(["PASS", "WARN", "FAIL", "NOT TESTED"], start=1):
+        _cell(ws_sum, r, col, label, bold=True, color=HDR_FONT,
+              fill_hex=HDR_FILL, align="center")
+    r += 1
+    fills  = [PASS_FILL,  WARN_FILL,  FAIL_FILL,  SKIP_FILL]
+    fonts  = [PASS_FONT,  WARN_FONT,  FAIL_FONT,  SKIP_FONT]
+    counts = [sut.pass_count, sut.warn_count, sut.fail_count, sut.skip_count]
+    for col, (fill, fnt, count) in enumerate(zip(fills, fonts, counts), start=1):
+        _cell(ws_sum, r, col, count, bold=True, color=fnt,
+              fill_hex=fill, align="center")
+
+    # Column widths — A (label) narrower, B-D equal data columns
+    ws_sum.column_dimensions["A"].width = 20
+    for col_letter in ["B", "C", "D"]:
+        ws_sum.column_dimensions[col_letter].width = 24
+
+    # Hide grid lines on summary sheet
+    ws_sum.sheet_view.showGridLines = False
+
+    # ── Results sheet ────────────────────────────────────────────────────────
+    ws = wb.create_sheet("Results")
+
+    # Column definitions: Category | Test Name | Description | Operation | Result | Message
+    col_headers = ["Category", "Test Name", "Description", "Operation", "Result", "Message"]
+    col_widths   = [22, 28, 40, 40, 12, 55]
+
+    for col, (hdr, width) in enumerate(zip(col_headers, col_widths), start=1):
+        _cell(ws, 1, col, hdr, bold=True, color=HDR_FONT,
+              fill_hex=HDR_FILL, align="center")
+        ws.column_dimensions[get_column_letter(col)].width = width
+    ws.row_dimensions[1].height = 20
+    ws.freeze_panes = "A2"
+
+    # Hide grid lines on results sheet
+    ws.sheet_view.showGridLines = False
+
+    row = 2
+    result_style = {
+        "PASS": (PASS_FILL, PASS_FONT),
+        "WARN": (WARN_FILL, WARN_FONT),
+        "FAIL": (FAIL_FILL, FAIL_FONT),
+    }
+
+    for test_category in sut._results:
+        category = test_category["Category"]
+        for test in test_category["Tests"]:
+            test_name = test["Name"]
+            description = test["Description"]
+            details = test.get("Details", "")
+            for result in test["Results"]:
+                operation = result["Operation"] or "No testing performed"
+                result_val = result["Result"] or "N/A"
+                message = result["Message"]
+
+                fill, fnt = result_style.get(result_val, (SKIP_FILL, SKIP_FONT))
+
+                _cell(ws, row, 1, category,    fill_hex=CAT_FILL,  color=HDR_FONT, wrap=True)
+                _cell(ws, row, 2, test_name,   fill_hex=TEST_FILL, bold=True, wrap=True)
+                _cell(ws, row, 3, description, fill_hex=TEST_FILL, wrap=True)
+                _cell(ws, row, 4, operation,   wrap=True)
+                _cell(ws, row, 5, result_val,  fill_hex=fill, color=fnt,
+                      bold=True, align="center")
+                _cell(ws, row, 6, message,     wrap=True)
+                ws.row_dimensions[row].height = 30
+                row += 1
+
+    wb.save(str(file))
+    return file
+

--- a/redfish_use_case_checkers/report.py
+++ b/redfish_use_case_checkers/report.py
@@ -20,204 +20,210 @@ html_template = """<!DOCTYPE html>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Redfish Use Case Checkers Report</title>
+  <title>Redfish Use Case Checkers &mdash; Test Report</title>
   <style>
     *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
-    :root {{
-      --primary:       #1a3a5c;
-      --primary-light: #0d6efd;
-      --accent:        #0d6efd;
-      --header-main-h: 56px;
-      --header-total-h: var(--header-main-h);
-      --pass-color:  #276749; --pass-bg:  #c6f6d5; --pass-border:  #38a169;
-      --warn-color:  #744210; --warn-bg:  #fefcbf; --warn-border:  #d69e2e;
-      --fail-color:  #742a2a; --fail-bg:  #fed7d7; --fail-border:  #e53e3e;
-      --skip-color:  #4a5568; --skip-bg:  #e2e8f0; --skip-border:  #a0aec0;
-      --border:   #dde3ec;
-      --text:     #1a1a2e;
-      --text-sub: #6c757d;
-      --bg:       #f0f2f5;
-      --card-bg:  #ffffff;
-    }}
+    html, body {{ height: 100%; }}
     body {{
       font-family: "Segoe UI", system-ui, Arial, sans-serif;
       font-size: 13px;
-      background: var(--bg);
-      color: var(--text);
-      line-height: 1.5;
+      background: #f0f2f5;
+      color: #1a1a2e;
       display: flex;
       flex-direction: column;
     }}
 
-    /* ── Header ── */
-    .header {{
-      position: sticky;
-      top: 0;
-      z-index: 100;
-      box-shadow: 0 2px 10px rgba(0,0,0,.35);
-    }}
-    .header-main {{
+    /* ════════════════════════════
+       TOP NAVBAR
+       ════════════════════════════ */
+    .top-nav {{
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      height: 56px;
       background: linear-gradient(90deg, #0d1b2a 0%, #1a3a5c 60%, #1565c0 100%);
-      color: #fff;
+      display: flex;
+      align-items: center;
       padding: 0 16px;
-      height: var(--header-main-h);
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
       gap: 10px;
-      position: relative;
+      z-index: 1000;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.35);
     }}
-    .header-brand    {{ display: flex; align-items: center; gap: .9rem; }}
-    .header-logo img {{ height: 34px; border-radius: 4px; }}
-    .header-title    {{ font-size: 15px; font-weight: 700; letter-spacing: .3px; white-space: nowrap; }}
-    .header-subtitle {{ font-size: 11px; color: rgba(255,255,255,.55); white-space: nowrap; }}
-    .header-meta     {{ color: rgba(255,255,255,.7); font-size: 11px; text-align: right; line-height: 1.5; margin-left: auto; flex-shrink: 0; }}
-    .header-meta a   {{ color: #90caf9; text-decoration: none; }}
-    .header-meta a:hover {{ text-decoration: underline; }}
-    .header-filter-wrap {{
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      width: 380px;
-    }}
-    .header-filter-shell {{ position: relative; width: 100%; }}
-    .header-filter-icon {{
-      position: absolute;
-      left: 10px;
-      top: 50%;
-      transform: translateY(-50%);
-      color: rgba(255,255,255,.5);
-      font-size: 14px;
-      pointer-events: none;
-    }}
-    .header-filter {{
-      width: 100%;
-      height: 30px;
-      border-radius: 20px;
-      border: 1px solid rgba(255,255,255,.35);
-      background: rgba(255,255,255,.12);
-      color: #f8fbff;
-      padding: 0 30px;
-      font-size: 12px;
-      font-family: "Cascadia Code", "Consolas", monospace;
-      outline: none;
-      transition: border-color .2s, box-shadow .2s;
-    }}
-    .header-filter::placeholder {{ color: rgba(255,255,255,.45); }}
-    .header-filter:focus {{
-      border-color: #90caf9;
-      box-shadow: 0 0 0 3px rgba(144,202,249,.2);
-      background: rgba(255,255,255,.18);
-    }}
-    .header-filter-clear {{
-      position: absolute;
-      right: 9px;
-      top: 50%;
-      transform: translateY(-50%);
-      background: none;
-      border: none;
-      color: rgba(255,255,255,.5);
-      cursor: pointer;
-      font-size: 13px;
-      line-height: 1;
-      display: none;
-    }}
-    .header-filter-clear:hover {{ color: #ef5350; }}
-    .header-filter-note {{
-      font-size: 10px;
-      color: rgba(255,255,255,.5);
-      margin-top: 2px;
-      text-align: center;
+    .top-nav img {{ height: 34px; border-radius: 4px; flex-shrink: 0; }}
+    .nav-brand {{ flex-shrink: 0; }}
+    .top-nav-title {{
+      color: #fff;
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: 0.3px;
       white-space: nowrap;
     }}
-    .header-filter-note b {{ color: #90caf9; }}
+    .top-nav-sub {{
+      color: rgba(255,255,255,0.55);
+      font-size: 11px;
+      white-space: nowrap;
+    }}
+    .top-nav-search-wrap {{
+      position: absolute;
+      left: 50%; transform: translateX(-50%);
+      display: flex; flex-direction: column; align-items: center;
+      width: 380px;
+      pointer-events: auto;
+    }}
+    .nav-filter-wrap {{ position: relative; width: 100%; }}
+    .nav-filter-wrap .fi {{
+      position: absolute; left: 10px; top: 50%;
+      transform: translateY(-50%);
+      color: rgba(255,255,255,0.5); font-size: 14px;
+      pointer-events: none;
+    }}
+    #uriFilter {{
+      width: 100%;
+      padding: 6px 30px 6px 30px;
+      border: 1px solid rgba(255,255,255,0.25);
+      border-radius: 20px;
+      font-size: 12px; outline: none;
+      transition: border-color 0.2s, box-shadow 0.2s;
+      font-family: "Cascadia Code","Consolas",monospace;
+      color: #fff;
+      background: rgba(255,255,255,0.12);
+    }}
+    #uriFilter::placeholder {{ color: rgba(255,255,255,0.45); }}
+    #uriFilter:focus {{
+      border-color: #90caf9;
+      box-shadow: 0 0 0 3px rgba(144,202,249,0.2);
+      background: rgba(255,255,255,0.2);
+    }}
+    #filterClear {{
+      position: absolute; right: 9px; top: 50%;
+      transform: translateY(-50%);
+      background: none; border: none; cursor: pointer;
+      color: rgba(255,255,255,0.5); font-size: 13px; line-height: 1;
+      display: none;
+    }}
+    #filterClear:hover {{ color: #ef5350; }}
+    .nav-filter-meta {{
+      font-size: 10px; color: rgba(255,255,255,0.5);
+      margin-top: 2px; text-align: center;
+    }}
+    .nav-filter-meta b {{ color: #90caf9; }}
+    .nav-hamburger {{
+      display: none;
+      align-items: center; justify-content: center;
+      width: 36px; height: 36px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: 6px; color: #fff; font-size: 18px;
+      cursor: pointer; flex-shrink: 0;
+    }}
+    .nav-hamburger:hover {{ background: rgba(255,255,255,0.2); }}
+    .top-nav-meta {{
+      color: rgba(255,255,255,0.7);
+      font-size: 11px;
+      text-align: right;
+      line-height: 1.5;
+      margin-left: auto;
+      flex-shrink: 0;
+    }}
+    .top-nav-meta a {{ color: #90caf9; text-decoration: none; }}
+    .top-nav-meta a:hover {{ text-decoration: underline; }}
 
-    /* ── Page layout ── */
-    .page-wrap {{ display: flex; align-items: flex-start; min-height: calc(100vh - var(--header-total-h)); }}
+    /* ════════════════════════════
+       APP SHELL  (sidebar + main)
+       ════════════════════════════ */
+    .app-shell {{
+      display: flex;
+      margin-top: 56px;
+      height: calc(100vh - 56px);
+      overflow: hidden;
+    }}
+    .sidebar-overlay {{
+      display: none;
+      position: fixed;
+      inset: 56px 0 0 0;
+      background: rgba(0,0,0,0.45);
+      z-index: 99;
+    }}
+    .sidebar-overlay.show {{ display: block; }}
     .sidebar {{
       width: 300px;
-      flex-shrink: 0;
-      background: #ffffff;
+      min-width: 300px;
+      background: #fff;
       border-right: 1px solid #dde3ec;
-      box-shadow: 2px 0 8px rgba(0,0,0,.04);
-      padding: 16px 18px 10px;
-      position: sticky;
-      top: var(--header-total-h);
-      height: calc(100vh - var(--header-total-h));
+      height: 100%;
       overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      box-shadow: 2px 0 8px rgba(0,0,0,0.04);
+      z-index: 100;
+      transition: left 0.3s ease;
     }}
-    .main-content {{ flex: 1; min-width: 0; padding: 20px 24px 60px; overflow-y: auto; }}
+    .sidebar::-webkit-scrollbar {{ width: 5px; }}
+    .sidebar::-webkit-scrollbar-thumb {{ background: #c8d3e0; border-radius: 3px; }}
+    .main-content {{
+      flex: 1;
+      min-width: 0;
+      padding: 20px 24px 60px;
+      overflow-y: auto;
+      overflow-x: hidden;
+      height: 100%;
+    }}
+    .main-content::-webkit-scrollbar {{ width: 6px; }}
+    .main-content::-webkit-scrollbar-thumb {{ background: #c8d3e0; border-radius: 3px; }}
+    a {{ color: #0d6efd; }}
 
-    /* ── Sidebar section headings ── */
-    .sb-heading {{
+    /* ── Sidebar sections ── */
+    .sidebar-section {{
+      padding: 16px 18px 10px;
+      border-bottom: 1px solid #edf0f5;
+    }}
+    .sidebar-section:last-child {{ border-bottom: none; }}
+    .sidebar-label {{
       font-size: 10px;
       font-weight: 800;
       text-transform: uppercase;
       letter-spacing: 1px;
       color: #8a97aa;
       margin-bottom: 10px;
+    }}
+
+    /* System info table in sidebar */
+    .sys-table {{ width: 100%; border-collapse: collapse; }}
+    .sys-table td {{
+      padding: 4px 0;
+      font-size: 12px;
       border: none;
       background: transparent;
-      padding: 0;
-      border-radius: 0;
-    }}
-    .sb-stats + .sb-heading {{ margin-top: 16px; }}
-
-    /* ── Sidebar info rows ── */
-    .sb-row {{
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      gap: .5rem;
-      padding: 4px 0;
-      border-bottom: none;
-      font-size: 12px;
-    }}
-    .sb-row:last-of-type {{ border-bottom: none; }}
-    .sb-key {{
-      color: #6c757d;
-      font-size: 12px;
-      font-weight: 600;
-      white-space: nowrap;
-      flex-shrink: 0;
-      min-width: 90px;
-    }}
-    .sb-val {{
-      font-weight: 600;
+      vertical-align: top;
       color: #333;
       word-break: break-all;
-      text-align: right;
-      font-size: 12px;
+    }}
+    .sys-table td:first-child {{
+      font-weight: 600;
+      color: #6c757d;
+      white-space: nowrap;
+      padding-right: 10px;
+      min-width: 90px;
     }}
 
-    /* ── Sidebar summary stat blocks — 2×2 grid ── */
-    .sb-stats {{
+    /* Score tiles in sidebar */
+    .score-grid {{
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 8px;
-      margin-top: 0;
     }}
-    .sb-stat {{
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      padding: 10px 12px;
+    .score-tile {{
       border-radius: 8px;
-      font-weight: 700;
+      padding: 10px 12px;
       color: #fff;
       text-align: center;
-      min-height: 72px;
+      font-weight: 700;
     }}
-    .sb-stat-count {{ font-size: 26px; line-height: 1.1; letter-spacing: -.02em; }}
-    .sb-stat-label {{ font-size: 10px; text-transform: uppercase; letter-spacing: .7px; margin-top: 2px; opacity: .9; line-height: 1.2; }}
-    .sb-stat.pass {{ background: linear-gradient(135deg, #27ae60, #2ecc71); }}
-    .sb-stat.warn {{ background: linear-gradient(135deg, #d68910, #f39c12); }}
-    .sb-stat.fail {{ background: linear-gradient(135deg, #c0392b, #e74c3c); }}
-    .sb-stat.skip {{ background: linear-gradient(135deg, #5d6d7e, #85929e); }}
+    .score-tile .snum {{ font-size: 26px; line-height: 1.1; }}
+    .score-tile .slbl {{ font-size: 10px; text-transform: uppercase; letter-spacing: 0.7px; margin-top: 2px; opacity: 0.9; }}
+    .st-pass {{ background: linear-gradient(135deg, #27ae60, #2ecc71); }}
+    .st-warn {{ background: linear-gradient(135deg, #d68910, #f39c12); }}
+    .st-fail {{ background: linear-gradient(135deg, #c0392b, #e74c3c); }}
+    .st-skip {{ background: linear-gradient(135deg, #5d6d7e, #85929e); }}
 
     /* ── Section ── */
     .section {{ margin-bottom: 1.5rem; }}
@@ -239,7 +245,7 @@ html_template = """<!DOCTYPE html>
     .section-arrow {{ font-size: .7rem; color: #6c757d; transition: transform .2s; }}
     .section-header.collapsed .section-arrow {{ transform: rotate(-90deg); }}
     .section-body {{
-      border: 1px solid var(--border);
+      border: 1px solid #dde3ec;
       border-top: none;
       border-radius: 0 0 8px 8px;
       overflow: hidden;
@@ -248,7 +254,7 @@ html_template = """<!DOCTYPE html>
     }}
 
     /* ── Test block ── */
-    .test-block {{ border-bottom: 1px solid var(--border); }}
+    .test-block {{ border-bottom: 1px solid #dde3ec; }}
     .test-block:last-child {{ border-bottom: none; }}
     .test-heading {{
       background: #fff;
@@ -263,7 +269,7 @@ html_template = """<!DOCTYPE html>
     .test-name   {{ font-weight: 700; font-size: 13px; color: #0d1b2a; font-family: "Cascadia Code", "Consolas", monospace; }}
     .test-desc   {{ font-size: 11px; color: #6c757d; margin-top: .12rem; font-style: italic; }}
     .test-detail {{ font-size: 11px; color: #6c757d; margin-top: .08rem; font-style: italic; }}
-    .test-toggle {{ flex-shrink: 0; font-size: .65rem; color: var(--text-sub); margin-top: .3rem; transition: transform .2s; }}
+    .test-toggle {{ flex-shrink: 0; font-size: .65rem; color: #6c757d; margin-top: .3rem; transition: transform .2s; }}
     .test-body         {{ display: block; }}
     .test-body.hidden  {{ display: none; }}
 
@@ -329,39 +335,20 @@ html_template = """<!DOCTYPE html>
     .toolbar-btn:hover {{ background: #0b5ed7; }}
 
     /* ── Scroll-to-top ── */
-    #scroll-top {{
+    #scrollTopBtn {{
       position: fixed;
-      bottom: 2rem;
-      right: 2rem;
-      width: 42px;
-      height: 42px;
+      bottom: 24px; right: 24px;
+      width: 42px; height: 42px;
       border-radius: 50%;
-      background: #0d6efd;
-      color: #fff;
-      border: none;
-      font-size: 1.1rem;
-      cursor: pointer;
-      box-shadow: 0 4px 14px rgba(13,110,253,.45);
-      display: none;
-      align-items: center;
-      justify-content: center;
-      z-index: 200;
-      transition: background .15s, opacity .2s;
-    }}
-    #scroll-top:hover {{ background: #0b5ed7; }}
-    #scroll-top.visible {{ display: flex; }}
-
-    /* ── Footer ── */
-    .footer {{
+      background: #0d6efd; color: #fff;
+      border: none; cursor: pointer;
+      font-size: 20px; line-height: 42px;
       text-align: center;
-      font-size: .77rem;
-      color: var(--text-sub);
-      padding: 2rem 1rem;
-      border-top: 1px solid var(--border);
-      margin-top: 2rem;
+      box-shadow: 0 4px 14px rgba(13,110,253,0.45);
+      display: none; z-index: 1100;
+      transition: background 0.2s, transform 0.2s;
     }}
-    .footer a {{ color: var(--accent); text-decoration: none; }}
-    .footer a:hover {{ text-decoration: underline; }}
+    #scrollTopBtn:hover {{ background: #0b5ed7; transform: translateY(-2px); }}
 
     /* ── Inline result summary chips (at most 4 per test) ── */
     .result-chips {{ display: flex; gap: .4rem; margin-top: .45rem; flex-wrap: wrap; }}
@@ -370,10 +357,10 @@ html_template = """<!DOCTYPE html>
       padding: .22rem .75rem; border-radius: 9999px;
       font-size: .72rem; font-weight: 700; white-space: nowrap; cursor: default;
     }}
-    .rchip-pass {{ background: var(--pass-bg); color: var(--pass-color); border: 1px solid var(--pass-border); }}
-    .rchip-warn {{ background: var(--warn-bg); color: var(--warn-color); border: 1px solid var(--warn-border); }}
-    .rchip-fail {{ background: var(--fail-bg); color: var(--fail-color); border: 1px solid var(--fail-border); }}
-    .rchip-skip {{ background: var(--skip-bg); color: var(--skip-color); border: 1px solid var(--skip-border); }}
+    .rchip-pass {{ background: #c6f6d5; color: #276749; border: 1px solid #38a169; }}
+    .rchip-warn {{ background: #fefcbf; color: #744210; border: 1px solid #d69e2e; }}
+    .rchip-fail {{ background: #fed7d7; color: #742a2a; border: 1px solid #e53e3e; }}
+    .rchip-skip {{ background: #e2e8f0; color: #4a5568; border: 1px solid #a0aec0; }}
 
     /* ── Section count badges ── */
     .section-counts {{ display: flex; gap: .35rem; margin-left: auto; flex-shrink: 0; align-items: center; }}
@@ -384,154 +371,137 @@ html_template = """<!DOCTYPE html>
     .scnt-skip {{ background: #f5f7fa; color: #7f8c8d; }}
 
     /* ── Test block status left border ── */
-    .test-block.tb-fail {{ border-left: 4px solid var(--fail-border); }}
-    .test-block.tb-warn {{ border-left: 4px solid var(--warn-border); }}
-    .test-block.tb-pass {{ border-left: 4px solid var(--pass-border); }}
+    .test-block.tb-fail {{ border-left: 4px solid #e53e3e; }}
+    .test-block.tb-warn {{ border-left: 4px solid #d69e2e; }}
+    .test-block.tb-pass {{ border-left: 4px solid #38a169; }}
 
-    /* ── Sidebar progress bar ── */
-    .sb-pass-rate {{
-      text-align: center;
-      margin: .5rem 0 .65rem;
+    /* Configuration toggle */
+    .btn-config {{
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 4px 12px; border-radius: 5px; cursor: pointer;
+      font-size: 11px; font-weight: 600; border: none;
+      background: #0d6efd; color: #fff;
+      transition: background 0.15s; user-select: none;
+      margin-bottom: 6px;
     }}
-    .sb-pass-rate-num {{
-      font-size: 1.9rem;
-      font-weight: 800;
-      color: #2d9e55;
-      letter-spacing: -.03em;
-      line-height: 1;
+    .btn-config:hover {{ background: #0b5ed7; }}
+    .config-panel {{ display: none; }}
+    .config-panel.open {{ display: block; }}
+    .config-table {{
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+      margin-top: 6px;
     }}
-    .sb-pass-rate-sub {{
-      font-size: .62rem;
-      color: #64748b;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: .07em;
-      margin-top: .18rem;
+    .config-table tr:nth-child(even) td {{ background: #f5f7fa; }}
+    .config-table tr:nth-child(odd) td {{ background: #ffffff; }}
+    .config-table td {{
+      padding: 5px 8px;
+      border: 1px solid #dde3ec;
+      vertical-align: top;
+      word-break: break-all;
+      color: #333;
     }}
-    .sb-prog-bar {{
-      height: 12px;
-      border-radius: 6px;
-      overflow: hidden;
-      display: flex;
-      background: #f0f3f7;
-      margin-bottom: .3rem;
-    }}
-    .sb-prog-seg {{
-      height: 100%;
-      width: 0%;
-      transition: width 1.2s cubic-bezier(.4,0,.2,1);
-    }}
-    .sb-prog-seg.pass {{ background: #2d9e55; }}
-    .sb-prog-seg.warn {{ background: #c98209; }}
-    .sb-prog-seg.fail {{ background: #c0392b; }}
-    .sb-prog-seg.skip {{ background: #cbd5e1; }}
-    .sb-prog-labels {{ display: flex; }}
-    .sb-prog-lbl {{
-      font-size: .62rem;
+    .config-table td:first-child {{
       font-weight: 700;
-      text-align: center;
-      overflow: hidden;
+      color: #1a3a5c;
       white-space: nowrap;
-      width: 0%;
-      transition: width 1.2s cubic-bezier(.4,0,.2,1);
+      width: 45%;
+      background: #eef4fb;
     }}
-    .sb-prog-lbl.pass {{ color: #2d9e55; }}
-    .sb-prog-lbl.warn {{ color: #c98209; }}
-    .sb-prog-lbl.fail {{ color: #c0392b; }}
-    .sb-prog-lbl.skip {{ color: #94a3b8; }}
+    .config-table td:last-child {{
+      font-weight: 400;
+      color: #444;
+    }}
 
     @media (max-width: 860px) {{
-      .header-filter-wrap {{ width: 240px; }}
-      .header-meta {{ display: none; }}
+      .nav-hamburger {{ display: flex; }}
+      .top-nav-search-wrap {{ width: 240px; }}
+      .top-nav-meta {{ display: none; }}
+      .sidebar {{
+        position: fixed;
+        left: -300px;
+        top: 56px;
+        height: calc(100vh - 56px);
+      }}
+      .sidebar.open {{ left: 0; }}
+      .main-content {{ width: 100%; }}
     }}
-
     @media (max-width: 540px) {{
-      .header-main {{ padding: 0 10px; }}
-      .header-logo img {{ height: 28px; }}
-      .header-brand > div:last-child {{ display: none; }}
-      .header-filter-wrap {{ width: 180px; }}
-      .sidebar {{ width: 260px; }}
+      .top-nav {{ padding: 0 10px; gap: 8px; }}
+      .top-nav img {{ height: 28px; }}
+      .nav-brand {{ display: none; }}
+      .top-nav-search-wrap {{ width: 180px; }}
     }}
   </style>
 </head>
 <body>
 
-<header class="header">
-  <div class="header-main">
-    <div class="header-brand">
-      <div class="header-logo">
-        <img src="data:image/gif;base64,{}" alt="DMTF Redfish Logo">
-      </div>
-      <div>
-        <div class="header-title">Redfish Use Case Checkers</div>
-        <div class="header-subtitle">Test Report</div>
-      </div>
-    </div>
-
-    <div class="header-filter-wrap">
-      <div class="header-filter-shell">
-        <span class="header-filter-icon">&#8260;</span>
-        <input id="header-uri-filter" class="header-filter" type="text" placeholder="Filter by Use Case..." aria-label="Filter by Use Case" autocomplete="off">
-        <button id="header-filter-clear" class="header-filter-clear" title="Clear">&#10005;</button>
-      </div>
-      <div class="header-filter-note">Showing <b id="header-filter-count">...</b> test blocks</div>
-    </div>
-
-    <div class="header-meta">
-      Version: {} &nbsp;|&nbsp; Generated: {}<br>
-      <a href="https://github.com/DMTF/Redfish-Use-Case-Checkers">github.com/DMTF/Redfish-Use-Case-Checkers</a>
-    </div>
+<nav class="top-nav">
+  <button class="nav-hamburger" id="hamburgerBtn" onclick="toggleSidebar()" title="Menu">&#9776;</button>
+  <img alt="DMTF Redfish Logo" src="data:image/gif;base64,{}"/>
+  <div class="nav-brand">
+    <div class="top-nav-title">Redfish Use Case Checkers</div>
+    <div class="top-nav-sub">Test Report</div>
   </div>
-</header>
+  <div class="top-nav-search-wrap">
+    <div class="nav-filter-wrap">
+      <span class="fi">&#8260;</span>
+      <input id="uriFilter" type="text" placeholder="Filter by Use Case&hellip;" autocomplete="off"/>
+      <button id="filterClear" onclick="clearFilter()" title="Clear">&#10005;</button>
+    </div>
+    <div class="nav-filter-meta">Showing <b id="filterCount">&#8230;</b> test blocks</div>
+  </div>
+  <div class="top-nav-meta">
+    Version: {} &nbsp;|&nbsp; Generated: {}<br/>
+    <a href="https://github.com/DMTF/Redfish-Use-Case-Checkers" target="_blank">DMTF/Redfish-Use-Case-Checkers</a>
+  </div>
+</nav>
 
-<div class="page-wrap">
+<div class="sidebar-overlay" id="sidebarOverlay" onclick="toggleSidebar()"></div>
+<div class="app-shell">
 
   <aside class="sidebar">
-    <div class="sb-heading">System Under Test</div>
-    <div class="sb-row"><span class="sb-key">Host</span><span class="sb-val">{}</span></div>
-    <div class="sb-row"><span class="sb-key">User</span><span class="sb-val"><strong>{}</strong></span></div>
-    <div class="sb-row"><span class="sb-key">Password</span><span class="sb-val">{}</span></div>
-    <div class="sb-row"><span class="sb-key">Product</span><span class="sb-val">{}</span></div>
-    <div class="sb-row"><span class="sb-key">Manufacturer</span><span class="sb-val">{}</span></div>
-    <div class="sb-row"><span class="sb-key">Model</span><span class="sb-val">{}</span></div>
-    <div class="sb-row"><span class="sb-key">Firmware</span><span class="sb-val">{}</span></div>
-    <div class="sb-heading" style="margin-top:1.25rem">Results Summary</div>
-    <div class="sb-stats">
-      <div class="sb-stat pass">
-        <span class="sb-stat-count">{}</span>
-        <span class="sb-stat-label">&#10003;<br>Pass</span>
-      </div>
-      <div class="sb-stat warn">
-        <span class="sb-stat-count">{}</span>
-        <span class="sb-stat-label">&#9888;<br>Warning</span>
-      </div>
-      <div class="sb-stat fail">
-        <span class="sb-stat-count">{}</span>
-        <span class="sb-stat-label">&#10007;<br>Fail</span>
-      </div>
-      <div class="sb-stat skip">
-        <span class="sb-stat-count">{}</span>
-        <span class="sb-stat-label">&ndash;<br>Not Tested</span>
+
+    <!-- System Info -->
+    <div class="sidebar-section">
+      <div class="sidebar-label">System Under Test</div>
+      <table class="sys-table">
+        <tr><td>Host</td><td>{}</td></tr>
+        <tr><td>User</td><td>{}</td></tr>
+        <tr><td>Password</td><td>{}</td></tr>
+        <tr><td>Product</td><td>{}</td></tr>
+        <tr><td>Manufacturer</td><td>{}</td></tr>
+        <tr><td>Model</td><td>{}</td></tr>
+        <tr><td>Firmware</td><td>{}</td></tr>
+      </table>
+    </div>
+
+    <!-- Score tiles -->
+    <div class="sidebar-section">
+      <div class="sidebar-label">Results Summary</div>
+      <div class="score-grid">
+        <div class="score-tile st-pass"><div class="snum">{}</div><div class="slbl">&#10003; Pass</div></div>
+        <div class="score-tile st-warn"><div class="snum">{}</div><div class="slbl">&#9888; Warning</div></div>
+        <div class="score-tile st-fail"><div class="snum">{}</div><div class="slbl">&#10007; Fail</div></div>
+        <div class="score-tile st-skip"><div class="snum">{}</div><div class="slbl">&#8212; Not Tested</div></div>
       </div>
     </div>
 
-    <div class="sb-heading" style="margin-top:1.25rem">Pass Rate</div>
-    <div class="sb-pass-rate">
-      <div class="sb-pass-rate-num" id="pass-rate-pct">—</div>
-      <div class="sb-pass-rate-sub">of all checks passed</div>
+    <!-- Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-label">Configuration</div>
+      <span class="btn-config" id="btnConfig"
+        onclick="(function(){{var p=document.getElementById('configPanel'),b=document.getElementById('btnConfig');if(p.classList.contains('open')){{p.classList.remove('open');b.innerHTML='&#9881; Show Configuration';}}else{{p.classList.add('open');b.innerHTML='&#9650; Hide Configuration';}}}})()">
+        &#9881; Show Configuration
+      </span>
+      <div class="config-panel" id="configPanel">
+        <table class="config-table">
+          {}
+        </table>
+      </div>
     </div>
-    <div class="sb-prog-bar">
-      <div class="sb-prog-seg pass" id="pseg-pass"></div>
-      <div class="sb-prog-seg warn" id="pseg-warn"></div>
-      <div class="sb-prog-seg fail" id="pseg-fail"></div>
-      <div class="sb-prog-seg skip" id="pseg-skip"></div>
-    </div>
-    <div class="sb-prog-labels">
-      <div class="sb-prog-lbl pass" id="plbl-pass"></div>
-      <div class="sb-prog-lbl warn" id="plbl-warn"></div>
-      <div class="sb-prog-lbl fail" id="plbl-fail"></div>
-      <div class="sb-prog-lbl skip" id="plbl-skip"></div>
-    </div>
+
   </aside>
 
   <div class="main-content">
@@ -544,18 +514,12 @@ html_template = """<!DOCTYPE html>
 
   </div>
 
-</div>
+</div><!-- /app-shell -->
 
-<button id="scroll-top" title="Back to top" onclick="window.scrollTo({{top:0,behavior:'smooth'}})">
+<button id="scrollTopBtn" title="Back to top"
+  onclick="document.querySelector('.main-content').scrollTo({{top:0,behavior:'smooth'}})">
   &#8679;
 </button>
-
-<footer class="footer">
-  This report was generated by the
-  <a href="https://github.com/DMTF/Redfish-Use-Case-Checkers">DMTF Redfish Use Case Checkers</a>.
-  For feedback, please
-  <a href="https://github.com/DMTF/Redfish-Use-Case-Checkers/issues">open an issue</a>.
-</footer>
 
 <script>
   /* Section collapse/expand */
@@ -608,52 +572,16 @@ html_template = """<!DOCTYPE html>
   }}
 
   /* Scroll-to-top button */
-  var scrollBtn = document.getElementById('scroll-top');
-  window.addEventListener('scroll', function() {{
-    if (window.scrollY > 400) {{
-      scrollBtn.classList.add('visible');
-    }} else {{
-      scrollBtn.classList.remove('visible');
-    }}
+  document.querySelector('.main-content').addEventListener('scroll', function() {{
+    document.getElementById('scrollTopBtn').style.display =
+      this.scrollTop > 200 ? 'block' : 'none';
   }});
 
-  /* ── Pass-rate progress bar animation ── */
+  /* URI filter */
   (function() {{
-    var keys = ['pass', 'warn', 'fail', 'skip'];
-    var counts = {{}};
-    var total = 0;
-    keys.forEach(function(k) {{
-      var el = document.querySelector('.sb-stat.' + k + ' .sb-stat-count');
-      counts[k] = el ? (parseInt(el.textContent, 10) || 0) : 0;
-      total += counts[k];
-    }});
-    if (!total) return;
-
-    /* Show overall pass-rate number immediately */
-    var pctPass = (counts.pass / total * 100);
-    var pctEl = document.getElementById('pass-rate-pct');
-    if (pctEl) pctEl.textContent = pctPass.toFixed(1) + '%';
-
-    /* Animate bars after a short paint delay */
-    setTimeout(function() {{
-      keys.forEach(function(k) {{
-        var pct = (counts[k] / total * 100);
-        var seg = document.getElementById('pseg-' + k);
-        var lbl = document.getElementById('plbl-' + k);
-        if (seg) seg.style.width = pct.toFixed(3) + '%';
-        if (lbl) {{
-          lbl.style.width = pct.toFixed(3) + '%';
-          lbl.textContent = counts[k] > 0 ? pct.toFixed(1) + '%' : '';
-        }}
-      }});
-    }}, 120);
-  }})();
-
-  /* Header URI filter (section and test title text match) */
-  (function() {{
-    var filter = document.getElementById('header-uri-filter');
-    var clearBtn = document.getElementById('header-filter-clear');
-    var countEl = document.getElementById('header-filter-count');
+    var filter = document.getElementById('uriFilter');
+    var clearBtn = document.getElementById('filterClear');
+    var countEl = document.getElementById('filterCount');
     if (!filter) return;
 
     function updateCount() {{
@@ -662,15 +590,8 @@ html_template = """<!DOCTYPE html>
       document.querySelectorAll('.test-block').forEach(function(tb) {{
         if (tb.style.display !== 'none') visibleTests += 1;
       }});
-      if (countEl) countEl.textContent = visibleTests + ' / ' + allTests;
+      if (countEl) countEl.innerHTML = '<b>' + visibleTests + '</b> / ' + allTests;
       if (clearBtn) clearBtn.style.display = filter.value.trim() ? 'block' : 'none';
-    }}
-
-    if (clearBtn) {{
-      clearBtn.addEventListener('click', function() {{
-        filter.value = '';
-        filter.dispatchEvent(new Event('input'));
-      }});
     }}
 
     filter.addEventListener('input', function() {{
@@ -706,6 +627,19 @@ html_template = """<!DOCTYPE html>
 
     updateCount();
   }})();
+
+  /* Mobile sidebar toggle */
+  function toggleSidebar() {{
+    var sb = document.querySelector('.sidebar');
+    var ov = document.getElementById('sidebarOverlay');
+    var open = sb.classList.toggle('open');
+    ov.classList.toggle('show', open);
+  }}
+
+  function clearFilter() {{
+    document.getElementById('uriFilter').value = '';
+    document.getElementById('uriFilter').dispatchEvent(new Event('input'));
+  }}
 </script>
 
 </body>
@@ -713,7 +647,7 @@ html_template = """<!DOCTYPE html>
 """
 
 
-def html_report(sut: SystemUnderTest, report_dir, time, tool_version):
+def html_report(sut: SystemUnderTest, report_dir, time, tool_version, args=None):
     """
     Creates the HTML report for the system under test
 
@@ -813,6 +747,21 @@ def html_report(sut: SystemUnderTest, report_dir, time, tool_version):
         html += '</div>'  # section-body
         html += '</div>'  # section
 
+    config_rows_html = ""
+    if args:
+        for key, val in sorted(args.items()):
+            if val is None:
+                val = ""
+            elif isinstance(val, list):
+                val = " ".join(str(v) for v in val)
+            else:
+                val = str(val)
+            if key in ("password",):
+                val = "********" if val else ""
+            config_rows_html += "<tr><td>{}</td><td>{}</td></tr>".format(
+                html_mod.escape(key), html_mod.escape(val)
+            )
+
     with open(str(file), "w", encoding="utf-8") as fd:
         fd.write(
             html_template.format(
@@ -830,6 +779,7 @@ def html_report(sut: SystemUnderTest, report_dir, time, tool_version):
                 sut.warn_count,
                 sut.fail_count,
                 sut.skip_count,
+                config_rows_html,
                 html,
             )
         )

--- a/redfish_use_case_checkers/report.py
+++ b/redfish_use_case_checkers/report.py
@@ -65,75 +65,90 @@ html_template = """<!DOCTYPE html>
     .header-meta     {{ text-align: right; font-size: .78rem; opacity: .85; line-height: 1.7; }}
     .header-meta a   {{ color: rgba(255,255,255,.7); font-size: .7rem; text-decoration: none; }}
 
-    /* ── Layout ── */
-    .container {{ max-width: 1200px; margin: 0 auto; padding: 2rem 1.5rem; }}
+    /* ── Page layout ── */
+    .page-wrap {{ display: flex; align-items: flex-start; min-height: calc(100vh - 64px); }}
+    .sidebar {{
+      width: 240px;
+      flex-shrink: 0;
+      background: #ffffff;
+      border-right: 1px solid #dde3ec;
+      box-shadow: 2px 0 8px rgba(0,0,0,.05);
+      padding: 1.4rem 1rem 2rem;
+      position: sticky;
+      top: 64px;
+      height: calc(100vh - 64px);
+      overflow-y: auto;
+    }}
+    .main-content {{ flex: 1; padding: 1.5rem; min-width: 0; }}
 
-    /* ── Info cards ── */
-    .info-grid {{
+    /* ── Sidebar section headings ── */
+    .sb-heading {{
+      font-size: .6rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: .12em;
+      color: var(--primary);
+      padding: .3rem .5rem;
+      background: #eef3fa;
+      border-left: 3px solid var(--accent);
+      border-radius: 0 4px 4px 0;
+      margin-bottom: .65rem;
+    }}
+    .sb-stats + .sb-heading {{ margin-top: 1.4rem; }}
+
+    /* ── Sidebar info rows ── */
+    .sb-row {{
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: .5rem;
+      padding: .32rem 0;
+      border-bottom: 1px solid #f0f3f7;
+      font-size: .78rem;
+    }}
+    .sb-row:last-of-type {{ border-bottom: none; }}
+    .sb-key {{
+      color: #64748b;
+      font-size: .67rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .05em;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }}
+    .sb-val {{
+      font-weight: 600;
+      color: #1e293b;
+      word-break: break-all;
+      text-align: right;
+      font-size: .78rem;
+    }}
+
+    /* ── Sidebar summary stat blocks — 2×2 grid ── */
+    .sb-stats {{
       display: grid;
       grid-template-columns: 1fr 1fr;
-      gap: 1rem;
-      margin-bottom: 1.5rem;
+      gap: .5rem;
+      margin-top: .4rem;
     }}
-    @media (max-width: 768px) {{ .info-grid {{ grid-template-columns: 1fr; }} }}
-    .card {{
-      background: var(--card-bg);
-      border: 1px solid var(--border);
+    .sb-stat {{
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: .7rem .4rem .55rem;
       border-radius: 8px;
-      padding: 1rem 1.25rem;
-      box-shadow: 0 1px 3px rgba(0,0,0,.06);
-    }}
-    .card-label {{
-      font-size: .67rem;
-      text-transform: uppercase;
-      letter-spacing: .08em;
-      color: var(--text-sub);
-      font-weight: 600;
-      margin-bottom: .2rem;
-    }}
-    .card-value {{ font-size: .9rem; font-weight: 500; word-break: break-all; }}
-    .hw-table {{ border-collapse: collapse; width: 100%; margin-top: .25rem; font-size: .88rem; }}
-    .hw-table tr {{ border-bottom: 1px solid var(--border); }}
-    .hw-table tr:last-child {{ border-bottom: none; }}
-    .hw-key {{ width: 30%; padding: .3rem .4rem .3rem 0; color: var(--text-sub); font-size: .75rem; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; white-space: nowrap; vertical-align: middle; }}
-    .hw-val {{ padding: .3rem .4rem; font-weight: 500; word-break: break-all; vertical-align: middle; }}
-
-    /* ── Summary counters ── */
-    .summary-grid {{
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      gap: 1rem;
-      margin-bottom: 2rem;
-    }}
-    @media (max-width: 640px) {{ .summary-grid {{ grid-template-columns: repeat(2, 1fr); }} }}
-    .summary-card {{
-      background: var(--card-bg);
-      border-radius: 8px;
-      padding: 1.25rem;
+      font-weight: 700;
+      color: #fff;
       text-align: center;
-      border: 1px solid var(--border);
-      box-shadow: 0 1px 3px rgba(0,0,0,.06);
+      min-height: 66px;
     }}
-    .summary-card .count {{ font-size: 2.25rem; font-weight: 700; line-height: 1; }}
-    .summary-card .label {{
-      font-size: .68rem;
-      text-transform: uppercase;
-      letter-spacing: .08em;
-      font-weight: 600;
-      margin-top: .3rem;
-    }}
-    .summary-card.pass {{ border-top: 4px solid var(--pass-border); }}
-    .summary-card.pass .count {{ color: var(--pass-color); }}
-    .summary-card.pass .label {{ color: var(--pass-border); }}
-    .summary-card.warn {{ border-top: 4px solid var(--warn-border); }}
-    .summary-card.warn .count {{ color: var(--warn-color); }}
-    .summary-card.warn .label {{ color: var(--warn-border); }}
-    .summary-card.fail {{ border-top: 4px solid var(--fail-border); }}
-    .summary-card.fail .count {{ color: var(--fail-color); }}
-    .summary-card.fail .label {{ color: var(--fail-border); }}
-    .summary-card.skip {{ border-top: 4px solid var(--skip-border); }}
-    .summary-card.skip .count {{ color: var(--skip-color); }}
-    .summary-card.skip .label {{ color: var(--skip-border); }}
+    .sb-stat-count {{ font-size: 1.7rem; line-height: 1; letter-spacing: -.02em; }}
+    .sb-stat-label {{ font-size: .58rem; text-transform: uppercase; letter-spacing: .08em; margin-top: .25rem; opacity: .92; line-height: 1.2; }}
+    .sb-stat.pass {{ background: #2d9e55; }}
+    .sb-stat.warn {{ background: #c98209; }}
+    .sb-stat.fail {{ background: #c0392b; }}
+    .sb-stat.skip {{ background: #5a6b7d; }}
 
     /* ── Section ── */
     .section {{ margin-bottom: 1.5rem; }}
@@ -274,6 +289,83 @@ html_template = """<!DOCTYPE html>
     }}
     .footer a {{ color: var(--accent); text-decoration: none; }}
     .footer a:hover {{ text-decoration: underline; }}
+
+    /* ── Inline result summary chips (at most 4 per test) ── */
+    .result-chips {{ display: flex; gap: .4rem; margin-top: .45rem; flex-wrap: wrap; }}
+    .rchip {{
+      display: inline-flex; align-items: center; gap: .3rem;
+      padding: .22rem .75rem; border-radius: 9999px;
+      font-size: .72rem; font-weight: 700; white-space: nowrap; cursor: default;
+    }}
+    .rchip-pass {{ background: var(--pass-bg); color: var(--pass-color); border: 1px solid var(--pass-border); }}
+    .rchip-warn {{ background: var(--warn-bg); color: var(--warn-color); border: 1px solid var(--warn-border); }}
+    .rchip-fail {{ background: var(--fail-bg); color: var(--fail-color); border: 1px solid var(--fail-border); }}
+    .rchip-skip {{ background: var(--skip-bg); color: var(--skip-color); border: 1px solid var(--skip-border); }}
+
+    /* ── Section count badges ── */
+    .section-counts {{ display: flex; gap: .35rem; margin-left: auto; flex-shrink: 0; align-items: center; }}
+    .scnt {{ padding: .12rem .58rem; border-radius: 9999px; font-size: .7rem; font-weight: 700; letter-spacing: .03em; }}
+    .scnt-pass {{ background: rgba(56,161,105,.35);   color: #c6f6d5; }}
+    .scnt-warn {{ background: rgba(214,158,46,.35);  color: #fefcbf; }}
+    .scnt-fail {{ background: rgba(229,62,62,.35);    color: #fed7d7; }}
+    .scnt-skip {{ background: rgba(160,174,192,.3);  color: #e2e8f0; }}
+
+    /* ── Test block status left border ── */
+    .test-block.tb-fail {{ border-left: 4px solid var(--fail-border); }}
+    .test-block.tb-warn {{ border-left: 4px solid var(--warn-border); }}
+    .test-block.tb-pass {{ border-left: 4px solid var(--pass-border); }}
+
+    /* ── Sidebar progress bar ── */
+    .sb-pass-rate {{
+      text-align: center;
+      margin: .5rem 0 .65rem;
+    }}
+    .sb-pass-rate-num {{
+      font-size: 1.9rem;
+      font-weight: 800;
+      color: #2d9e55;
+      letter-spacing: -.03em;
+      line-height: 1;
+    }}
+    .sb-pass-rate-sub {{
+      font-size: .62rem;
+      color: #64748b;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .07em;
+      margin-top: .18rem;
+    }}
+    .sb-prog-bar {{
+      height: 12px;
+      border-radius: 6px;
+      overflow: hidden;
+      display: flex;
+      background: #f0f3f7;
+      margin-bottom: .3rem;
+    }}
+    .sb-prog-seg {{
+      height: 100%;
+      width: 0%;
+      transition: width 1.2s cubic-bezier(.4,0,.2,1);
+    }}
+    .sb-prog-seg.pass {{ background: #2d9e55; }}
+    .sb-prog-seg.warn {{ background: #c98209; }}
+    .sb-prog-seg.fail {{ background: #c0392b; }}
+    .sb-prog-seg.skip {{ background: #cbd5e1; }}
+    .sb-prog-labels {{ display: flex; }}
+    .sb-prog-lbl {{
+      font-size: .62rem;
+      font-weight: 700;
+      text-align: center;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 0%;
+      transition: width 1.2s cubic-bezier(.4,0,.2,1);
+    }}
+    .sb-prog-lbl.pass {{ color: #2d9e55; }}
+    .sb-prog-lbl.warn {{ color: #c98209; }}
+    .sb-prog-lbl.fail {{ color: #c0392b; }}
+    .sb-prog-lbl.skip {{ color: #94a3b8; }}
   </style>
 </head>
 <body>
@@ -294,44 +386,65 @@ html_template = """<!DOCTYPE html>
   </div>
 </header>
 
-<div class="container">
+<div class="page-wrap">
 
-  <div class="info-grid">
-    <div class="card">
-      <div class="card-label">Target System</div>
-      <div class="card-value">{}/redfish/v1/</div>
+  <aside class="sidebar">
+    <div class="sb-heading">System Under Test</div>
+    <div class="sb-row"><span class="sb-key">Host</span><span class="sb-val">{}/redfish/v1/</span></div>
+    <div class="sb-row"><span class="sb-key">User</span><span class="sb-val"><strong>{}</strong></span></div>
+    <div class="sb-row"><span class="sb-key">Password</span><span class="sb-val">{}</span></div>
+    <div class="sb-row"><span class="sb-key">Product</span><span class="sb-val">{}</span></div>
+    <div class="sb-row"><span class="sb-key">Manufacturer</span><span class="sb-val">{}</span></div>
+    <div class="sb-row"><span class="sb-key">Model</span><span class="sb-val">{}</span></div>
+    <div class="sb-row"><span class="sb-key">Firmware</span><span class="sb-val">{}</span></div>
+    <div class="sb-heading" style="margin-top:1.25rem">Results Summary</div>
+    <div class="sb-stats">
+      <div class="sb-stat pass">
+        <span class="sb-stat-count">{}</span>
+        <span class="sb-stat-label">&#10003;<br>Pass</span>
+      </div>
+      <div class="sb-stat warn">
+        <span class="sb-stat-count">{}</span>
+        <span class="sb-stat-label">&#9888;<br>Warning</span>
+      </div>
+      <div class="sb-stat fail">
+        <span class="sb-stat-count">{}</span>
+        <span class="sb-stat-label">&#10007;<br>Fail</span>
+      </div>
+      <div class="sb-stat skip">
+        <span class="sb-stat-count">{}</span>
+        <span class="sb-stat-label">&ndash;<br>Not Tested</span>
+      </div>
     </div>
-    <div class="card">
-      <div class="card-label">Credentials</div>
-      <div class="card-value">User:&nbsp;<strong>{}</strong>&nbsp;&nbsp;|&nbsp;&nbsp;Password:&nbsp;{}</div>
+
+    <div class="sb-heading" style="margin-top:1.25rem">Pass Rate</div>
+    <div class="sb-pass-rate">
+      <div class="sb-pass-rate-num" id="pass-rate-pct">—</div>
+      <div class="sb-pass-rate-sub">of all checks passed</div>
     </div>
-    <div class="card">
-      <div class="card-label">Product</div>
-      <div class="card-value">{}</div>
+    <div class="sb-prog-bar">
+      <div class="sb-prog-seg pass" id="pseg-pass"></div>
+      <div class="sb-prog-seg warn" id="pseg-warn"></div>
+      <div class="sb-prog-seg fail" id="pseg-fail"></div>
+      <div class="sb-prog-seg skip" id="pseg-skip"></div>
     </div>
-    <div class="card">
-      <div class="card-label">Hardware</div>
-      <table class="hw-table">
-        <tr><td class="hw-key">Manufacturer</td><td class="hw-val">{}</td></tr>
-        <tr><td class="hw-key">Model</td><td class="hw-val">{}</td></tr>
-        <tr><td class="hw-key">Firmware</td><td class="hw-val">{}</td></tr>
-      </table>
+    <div class="sb-prog-labels">
+      <div class="sb-prog-lbl pass" id="plbl-pass"></div>
+      <div class="sb-prog-lbl warn" id="plbl-warn"></div>
+      <div class="sb-prog-lbl fail" id="plbl-fail"></div>
+      <div class="sb-prog-lbl skip" id="plbl-skip"></div>
     </div>
+  </aside>
+
+  <div class="main-content">
+    <div class="toolbar">
+      <button class="toolbar-btn" onclick="expandAll()">&#9660;&nbsp; Expand All</button>
+      <button class="toolbar-btn" onclick="collapseAll()">&#9654;&nbsp; Collapse All</button>
+    </div>
+
+    {}
+
   </div>
-
-  <div class="summary-grid">
-    <div class="summary-card pass"><div class="count">{}</div><div class="label">Pass</div></div>
-    <div class="summary-card warn"><div class="count">{}</div><div class="label">Warning</div></div>
-    <div class="summary-card fail"><div class="count">{}</div><div class="label">Fail</div></div>
-    <div class="summary-card skip"><div class="count">{}</div><div class="label">Not Tested</div></div>
-  </div>
-
-  <div class="toolbar">
-    <button class="toolbar-btn" onclick="expandAll()">&#9660;&nbsp; Expand All</button>
-    <button class="toolbar-btn" onclick="collapseAll()">&#9654;&nbsp; Collapse All</button>
-  </div>
-
-  {}
 
 </div>
 
@@ -405,6 +518,38 @@ html_template = """<!DOCTYPE html>
       scrollBtn.classList.remove('visible');
     }}
   }});
+
+  /* ── Pass-rate progress bar animation ── */
+  (function() {{
+    var keys = ['pass', 'warn', 'fail', 'skip'];
+    var counts = {{}};
+    var total = 0;
+    keys.forEach(function(k) {{
+      var el = document.querySelector('.sb-stat.' + k + ' .sb-stat-count');
+      counts[k] = el ? (parseInt(el.textContent, 10) || 0) : 0;
+      total += counts[k];
+    }});
+    if (!total) return;
+
+    /* Show overall pass-rate number immediately */
+    var pctPass = (counts.pass / total * 100);
+    var pctEl = document.getElementById('pass-rate-pct');
+    if (pctEl) pctEl.textContent = pctPass.toFixed(1) + '%';
+
+    /* Animate bars after a short paint delay */
+    setTimeout(function() {{
+      keys.forEach(function(k) {{
+        var pct = (counts[k] / total * 100);
+        var seg = document.getElementById('pseg-' + k);
+        var lbl = document.getElementById('plbl-' + k);
+        if (seg) seg.style.width = pct.toFixed(3) + '%';
+        if (lbl) {{
+          lbl.style.width = pct.toFixed(3) + '%';
+          lbl.textContent = counts[k] > 0 ? pct.toFixed(1) + '%' : '';
+        }}
+      }});
+    }}, 120);
+  }})();
 </script>
 
 </body>
@@ -430,20 +575,52 @@ def html_report(sut: SystemUnderTest, report_dir, time, tool_version):
 
     html = ""
     for test_category in sut._results:
+        # Aggregate counts for section header badges
+        sec_pass = sum(1 for t in test_category["Tests"] for r in t["Results"] if r["Result"] == "PASS")
+        sec_warn = sum(1 for t in test_category["Tests"] for r in t["Results"] if r["Result"] == "WARN")
+        sec_fail = sum(1 for t in test_category["Tests"] for r in t["Results"] if r["Result"] == "FAIL")
+        sec_skip = sum(1 for t in test_category["Tests"] for r in t["Results"] if not r["Result"])
+        sec_cnt = '<div class="section-counts">'
+        if sec_pass: sec_cnt += '<span class="scnt scnt-pass">&#10003;&nbsp;{}</span>'.format(sec_pass)
+        if sec_warn: sec_cnt += '<span class="scnt scnt-warn">&#9888;&nbsp;{}</span>'.format(sec_warn)
+        if sec_fail: sec_cnt += '<span class="scnt scnt-fail">&#10007;&nbsp;{}</span>'.format(sec_fail)
+        if sec_skip: sec_cnt += '<span class="scnt scnt-skip">&ndash;&nbsp;{}</span>'.format(sec_skip)
+        sec_cnt += '</div>'
         html += '<div class="section">'
-        html += '<div class="section-header"><span class="section-arrow">&#9660;</span>{}</div>'.format(
-            html_mod.escape(test_category["Category"])
+        html += '<div class="section-header"><span class="section-arrow">&#9660;</span>{}{}</div>'.format(
+            html_mod.escape(test_category["Category"]), sec_cnt
         )
         html += '<div class="section-body">'
 
         for test in test_category["Tests"]:
-            html += '<div class="test-block">'
+            # Determine worst result for status left-border
+            _rvals = [r["Result"] for r in test["Results"]]
+            if "FAIL" in _rvals:
+                tb_cls = " tb-fail"
+            elif "WARN" in _rvals:
+                tb_cls = " tb-warn"
+            elif "PASS" in _rvals:
+                tb_cls = " tb-pass"
+            else:
+                tb_cls = ""
+            html += '<div class="test-block{}">' .format(tb_cls)
             html += '<div class="test-heading">'
             html += '<div class="test-heading-info">'
             html += '<div class="test-name">{}</div>'.format(html_mod.escape(test["Name"]))
             html += '<div class="test-desc">{}</div>'.format(html_mod.escape(test["Description"]))
             if test.get("Details"):
                 html += '<div class="test-detail">{}</div>'.format(html_mod.escape(test["Details"]))
+            # Inline result summary chips — aggregate counts (max 4 chips per test)
+            t_pass = sum(1 for _r in test["Results"] if _r["Result"] == "PASS")
+            t_warn = sum(1 for _r in test["Results"] if _r["Result"] == "WARN")
+            t_fail = sum(1 for _r in test["Results"] if _r["Result"] == "FAIL")
+            t_skip = sum(1 for _r in test["Results"] if not _r["Result"])
+            html += '<div class="result-chips">'
+            if t_pass: html += '<span class="rchip rchip-pass">&#10003; {} Pass</span>'.format(t_pass)
+            if t_warn: html += '<span class="rchip rchip-warn">&#9888; {} Warn</span>'.format(t_warn)
+            if t_fail: html += '<span class="rchip rchip-fail">&#10007; {} Fail</span>'.format(t_fail)
+            if t_skip: html += '<span class="rchip rchip-skip">&ndash; {} N/A</span>'.format(t_skip)
+            html += '</div>'
             html += '</div>'  # test-heading-info
             html += '<span class="test-toggle">&#9660;</span>'
             html += '</div>'  # test-heading

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 colorama
+openpyxl
 redfish>=3.0.0
 redfish_utilities>=3.4.3


### PR DESCRIPTION
1. Iteration-1

#### Create timestamped run folders and suppress warnings

- Each run now creates a subdirectory under the report directory named YYYY-MM-DD-HH-SS (e.g. reports/2026-05-02-18-46), keeping the HTML report and debug log for each run isolated.
- Suppress RequestsDependencyWarning emitted by the requests library on import, which was cluttering the tool's console output.

<img width="577" height="140" alt="image" src="https://github.com/user-attachments/assets/a806f38c-aca9-4744-bae6-57a6f978564e" />

Reports : 

<img width="570" height="322" alt="image" src="https://github.com/user-attachments/assets/e7f859d5-c152-42a5-b8d5-732cab99c074" />


_________________________________________________________________________________________________________________________________

2. Iteration-2


-  Report output directory is now organised into timestamped sub-folders (`YYYY-MM-DD-HH-SS`) under the configured report directory
-  `RequestsDependencyWarning` from the `requests` library is suppressed at startup
-  HTML report redesigned with a responsive, enterprise-grade layout:
  - Sticky header with DMTF Redfish logo, tool version, and generation timestamp
  - Info cards for target system, credentials, product, and hardware details
  - Colour-coded summary counter cards (PASS / WARN / FAIL / NOT TESTED)
  - Collapsible category sections and collapsible test rows
  - Pill-style result badges (PASS / WARN / FAIL / NOT TESTED)
  - Expand All / Collapse All toolbar buttons
  - Scroll-to-top button that appears after scrolling 400 px
-  Excel (`.xlsx`) report generated alongside the HTML report:
  - **Summary** sheet — title, metadata, and colour-coded counter table; grid lines hidden
  - **Results** sheet — one row per result with Category, Test Name, Description, Operation, Result (colour-coded), and Message columns; frozen header row; grid lines hidden
-  Console summary output changed from a single comma-separated line to a formatted ASCII table with colour-coded columns
-  Blank lines added between console output entries (Summary, HTML Report, Excel Report, Debug Log) for readability
-  `openpyxl` added to `requirements.txt`

```shell
sivaprabug$ rf_use_case_checkers -r https://10.0.139.128 -u root -p 0penBmc
Redfish Use Case Checkers, Version 2.0.8

Performing Account Management use cases...
-- Running the User Count test...
-- Running the Add User test...
-- Running the Enable User test...
-- Running the Disable Password Change Required test...
-- Running the Credential Check test...
-- Running the Change Role test...
-- Running the Delete User test...

Performing Power Control use cases...
-- Running the System Count test...
-- Running the Reset Type test...
-- Running the Reset Operation test...

Performing Boot Override use cases...
-- Running the System Count test...
-- Running the Boot Override Check test...
-- Running the Continuous Boot Override test...
-- Running the One-Time Boot Override test...
-- Running the One-Time Boot Override Check test...
-- Running the Disable Boot Override test...

Performing Manager Ethernet Interfaces use cases...
-- Running the Ethernet Interface Count test...
-- Running the VLAN Check test...
-- Running the Addresses Check test...

Performing Query Parameters use cases...
-- Running the Filter Query test...
-- Running the Select Query test...
-- Running the Expand Query test...
-- Running the Only Query test...


+--------------+--------------+--------------+--------------+
|     PASS     |     WARN     |     FAIL     |  NOT TESTED  |
+--------------+--------------+--------------+--------------+
|     141      |      1       |      10      |      21      |
+--------------+--------------+--------------+--------------+


HTML Report:  reports/2026-05-02-21-03/RedfishUseCaseCheckersReport_05_02_2026_210203.html

Excel Report: reports/2026-05-02-21-03/RedfishUseCaseCheckersReport_05_02_2026_210203.xlsx

Debug Log:    reports/2026-05-02-21-03/RedfishUseCaseCheckersDebug_05_02_2026_210203.log

```
HTML Report:  [RedfishUseCaseCheckersReport_05_02_2026_210203.html](https://github.com/user-attachments/files/27304713/RedfishUseCaseCheckersReport_05_02_2026_210203.html)



Excel Report: [RedfishUseCaseCheckersReport_05_02_2026_210203.xlsx](https://github.com/user-attachments/files/27304714/RedfishUseCaseCheckersReport_05_02_2026_210203.xlsx)

Debug Log:    [RedfishUseCaseCheckersDebug_05_02_2026_210203.log](https://github.com/user-attachments/files/27304712/RedfishUseCaseCheckersDebug_05_02_2026_210203.log)

Screenshots: 

Spread Sheet : 

Summary : 

<img width="674" height="778" alt="image" src="https://github.com/user-attachments/assets/7434290b-6a43-4b5d-bd06-9fe7647b5a59" />

Results : 

<img width="1467" height="832" alt="image" src="https://github.com/user-attachments/assets/c7c3f1e9-d3e0-496e-b270-fe92d93a89e3" />

HTML Report : 

Expanded Report:

<img width="1920" height="12853" alt="image" src="https://github.com/user-attachments/assets/49f38b9d-63b3-4446-adf4-15b63998ee3c" />

Collapsed Report : 

<img width="1920" height="1031" alt="image" src="https://github.com/user-attachments/assets/eb91bf69-52bd-4b5d-a276-984a9ba88cfb" />



_________________________________________________________________________________________________________________________________

CC: @jautor  @tomasg2012 @billdodd @mraineri